### PR TITLE
Use official GitHub Actions to deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,27 @@ jobs:
       - name: Add CNAME
         run: echo "www.foss4g.be" > .output/public/CNAME
 
-      # 6. Deploy to GitHub Pages
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      # 6. Upload artifact
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .output/public
+          path: .output/public
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    runs-on: ubuntu-latest
+    
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+      
+    steps:
+      # 1. Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - b2025-2
 
-permissions:
-  contents: write
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/actions/upload-pages-artifact and https://github.com/actions/deploy-pages

> [!NOTE]
> You can now remove your `GITHUB_TOKEN` secret. It's not needed anymore.  
> GitHub uses the built-in `${{ github.token }}`.