### PR TITLE
Extract sponsors in a .json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ Simply push your changes to this branch;
 To add translations, add them in the `locales` folder.
 If the translation key doesn't exist yet, you'll need to add it in the three different languages: `en`, `fr`, and `nl` but also in the template files in the `pages` folder.
 
-### Add a sponsor
-To add a sponsor:
-- add the logo in the `public/sponsors` folder
-- add a record in the `sponsors` variable in the `pages/sponsors.vue` file
+### Edit sponsors
+To edit sponsors, edit the `sponsors.json` file in the `assets/data` folder.
 

--- a/assets/sponsors-data.json
+++ b/assets/sponsors-data.json
@@ -1,0 +1,42 @@
+{
+  "gold": [],
+  "silver": [
+    {
+      "id": 1,
+      "name": "Champs libres",
+      "link": "https://www.champs-libres.coop",
+      "logo": "/images/sponsors/champslibres-logo.svg",
+      "bgClass": "bg-white"
+    },
+    {
+      "id": 2,
+      "name": "Geo Solutions",
+      "link": "https://geosolutions.be/",
+      "logo": "/images/sponsors/geosolutions-logo.jpg",
+      "bgClass": "bg-white"
+    },
+    {
+      "id": 3,
+      "name": "TomTom",
+      "link": "https://www.tomtom.com/",
+      "logo": "/images/sponsors/tomtom_logo.svg",
+      "bgClass": "bg-white"
+    }
+  ],
+  "bronze": [
+    {
+      "id": 4,
+      "name": "Atelier Cartographique",
+      "link": "https://atelier-cartographique.be/",
+      "logo": "/images/sponsors/ateliercartographique-logo.svg",
+      "bgClass": "bg-white"
+    },
+    {
+      "id": 5,
+      "name": "Spacebel",
+      "link": "https://www.spacebel.com/",
+      "logo": "/images/sponsors/spacebel-logo.svg",
+      "bgClass": "bg-white"
+    }
+  ]
+}

--- a/pages/become-sponsor.vue
+++ b/pages/become-sponsor.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import sponsorsData from '~/assets/sponsors-data.json'
+import type { Sponsor } from '~/types/sponsors'
+
 // array of i18n keys:
 const tiers = [
     {
@@ -41,56 +44,10 @@ const tiers = [
     },
 ]
 
-interface Sponsor {
-    id: number;
-    name: string;
-    link: string;
-    logo: string;
-    bgClass: string;
-}
-
-const goldSponsors: Sponsor[] = []
-
-const silverSponsors: Sponsor[] = [
-    {
-        id: 1,
-        name: 'Champs libres',
-        link: 'https://www.champs-libres.coop',
-        logo: '/images/sponsors/champslibres-logo.svg',
-        bgClass: 'bg-white',
-    },
-    {
-        id: 2,
-        name: 'Geo Solutions',
-        link: 'https://geosolutions.be/',
-        logo: '/images/sponsors/geosolutions-logo.jpg',
-        bgClass: 'bg-white',
-    },
-    {
-        id: 5,
-        name: 'TomTom',
-        link: 'https://www.tomtom.com/',
-        logo: '/images/sponsors/tomtom_logo.svg',
-        bgClass: 'bg-white',
-    },
-]
-
-const bronzeSponsors: Sponsor[] = [
-    {
-        id: 3,
-        name: 'Atelier Cartographique',
-        link: 'https://atelier-cartographique.be/',
-        logo: '/images/sponsors/ateliercartographique-logo.svg',
-        bgClass: 'bg-white',
-    },
-    {
-        id: 4,
-        name: 'Spacebel',
-        link: 'https://www.spacebel.com/',
-        logo: '/images/sponsors/spacebel-logo.svg',
-        bgClass: 'bg-white',
-    },
-]
+// Use centralized sponsor data
+const goldSponsors: Sponsor[] = sponsorsData.gold
+const silverSponsors: Sponsor[] = sponsorsData.silver
+const bronzeSponsors: Sponsor[] = sponsorsData.bronze
 
 </script>
 

--- a/pages/our-sponsors.vue
+++ b/pages/our-sponsors.vue
@@ -1,87 +1,11 @@
 <script setup lang="ts">
-import { NuxtLink } from '#components'
+import sponsorsData from '~/assets/sponsors-data.json'
+import type { Sponsor } from '~/types/sponsors'
 
-// array of i18n keys:
-const tiers = [
-    {
-        key: 'Gold',
-        titleKey: 'sponsors.tiers.gold.title',
-        priceKey: 'sponsors.tiers.gold.price',
-        banner: 'bg-gold',
-        advantages: [
-            'sponsors.tiers.gold.features.0',
-            'sponsors.tiers.gold.features.1',
-            'sponsors.tiers.gold.features.2',
-        ],
-        ctaKey: 'sponsors.tiers.gold.cta',
-    },
-    {
-        key: 'Silver',
-        titleKey: 'sponsors.tiers.silver.title',
-        priceKey: 'sponsors.tiers.silver.price',
-        banner: 'bg-silver',
-        advantages: [
-            'sponsors.tiers.silver.features.0',
-            'sponsors.tiers.silver.features.1',
-        ],
-        ctaKey: 'sponsors.tiers.silver.cta',
-    },
-    {
-        key: 'Bronze',
-        titleKey: 'sponsors.tiers.bronze.title',
-        priceKey: 'sponsors.tiers.bronze.price',
-        banner: 'bg-bronze',
-        advantages: [
-            'sponsors.tiers.bronze.features.0',
-            'sponsors.tiers.bronze.features.1',
-        ],
-        ctaKey: 'sponsors.tiers.bronze.cta',
-    },
-]
-
-const sponsors_gold = [
-]
-
-const sponsors_silver = [
-    {
-        id: 1,
-        name: 'Champs libres',
-        link: 'https://www.champs-libres.coop',
-        logo: '/images/sponsors/champslibres-logo.svg',
-        bgClass: 'bg-white',
-    },
-    {
-        id: 2,
-        name: 'Geo Solutions',
-        link: 'https://geosolutions.be/',
-        logo: '/images/sponsors/geosolutions-logo.jpg',
-        bgClass: 'bg-white',
-    },
-    {
-        id: 5,
-        name: 'TomTom',
-        link: 'https://www.tomtom.com/',
-        logo: '/images/sponsors/tomtom_logo.svg',
-        bgClass: 'bg-white',
-    },
-]
-
-const sponsors_bronze = [
-    {
-        id: 3,
-        name: 'Atelier Cartographique',
-        link: 'https://atelier-cartographique.be/',
-        logo: '/images/sponsors/ateliercartographique-logo.svg',
-        bgClass: 'bg-white',
-    },
-    {
-        id: 4,
-        name: 'Spacebel',
-        link: 'https://www.spacebel.com/',
-        logo: '/images/sponsors/spacebel-logo.svg',
-        bgClass: 'bg-white',
-    },
-]
+// Use centralized sponsor data
+const sponsors_gold: Sponsor[] = sponsorsData.gold
+const sponsors_silver: Sponsor[] = sponsorsData.silver
+const sponsors_bronze: Sponsor[] = sponsorsData.bronze
 </script>
 
 <template>

--- a/types/sponsors.ts
+++ b/types/sponsors.ts
@@ -1,0 +1,13 @@
+export interface Sponsor {
+  id: number
+  name: string
+  link: string
+  logo: string
+  bgClass: string
+}
+
+export interface SponsorsData {
+  gold: Sponsor[]
+  silver: Sponsor[]
+  bronze: Sponsor[]
+}


### PR DESCRIPTION
This pull request centralizes sponsor data management by introducing a single JSON file for all sponsor information and updates the codebase to reference this file. This change simplifies sponsor updates and ensures consistency across different pages. Additionally, sponsor type definitions are moved to a shared TypeScript file for better maintainability.

**Centralization of sponsor data:**
* Added a new `sponsors-data.json` file in the `assets` directory to store all sponsor information in one place, organized by sponsorship tier.
* Updated both `pages/become-sponsor.vue` and `pages/our-sponsors.vue` to import sponsor data from the centralized JSON file instead of maintaining separate arrays in each component. [[1]](diffhunk://#diff-56b579b9839055af624c1f39b101504db554cc9e3c8c43f3531d910d683ec482R2-R4) [[2]](diffhunk://#diff-56b579b9839055af624c1f39b101504db554cc9e3c8c43f3531d910d683ec482L44-R50) [[3]](diffhunk://#diff-2d27f2e4ec09addd330b2fddf61dbcd7cdb4c09cf061077235670b25087573c5L2-R8)

**Type definitions and code cleanup:**
* Created a new `Sponsor` and `SponsorsData` interface in `types/sponsors.ts` to standardize sponsor data types across the project.
* Removed redundant sponsor arrays and inline type definitions from the Vue components, replacing them with imports from the shared type file and the centralized data source. [[1]](diffhunk://#diff-56b579b9839055af624c1f39b101504db554cc9e3c8c43f3531d910d683ec482L44-R50) [[2]](diffhunk://#diff-2d27f2e4ec09addd330b2fddf61dbcd7cdb4c09cf061077235670b25087573c5L2-R8)

**Documentation update:**
* Updated the sponsor management instructions in `README.md` to direct users to edit the centralized `sponsors.json` file, reflecting the new workflow.