### PR TITLE
schedule: programme 2026 + styles workshops + noms salles

### DIFF
--- a/assets/schedule-data.json
+++ b/assets/schedule-data.json
@@ -1,1 +1,328 @@
-[]
+[
+  {
+    "time": "08:30",
+    "event": {
+      "title": "Welcome & Registration",
+      "speakers": [],
+      "type": "registration"
+    }
+  },
+  {
+    "time": "09:00",
+    "event": {
+      "title": "Keynote Speeches: The Future of Free & Open Source Geospatial",
+      "speakers": [],
+      "type": "keynote"
+    }
+  },
+  {
+    "time": "09:30",
+    "event": {
+      "title": "Coffee Break",
+      "speakers": [],
+      "type": "break"
+    }
+  },
+  {
+    "time": "10:00",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "API de geocoding - registre authentique bruxellois au format BeSt",
+        "speakers": [{ "name": "Benoît Fricheteau", "organization": "Paradigm" }],
+        "languages": ["FR"],
+        "abstract": "Paradigm a publié une API de geocoding ouverte à tous et à toutes. Celle-ci permet d'interroger de différentes manières le registre authentique d'adresses de la région notamment en vue d'obtenir des adresses. L'API renvoie ces objets sous différents formats, parmi lesquels le format prévu par la norme BeSt Address.",
+        "duration": 20,
+        "tags": ["API", "WebGIS", "Geocoding", "BeSt Address"]
+      },
+      {
+        "track": "track_2",
+        "title": "Collaborative Data Collection with QGIS & Mergin Maps: What's New",
+        "speakers": [{ "name": "Tomas Mizera", "organization": "Mergin Maps" }],
+        "languages": ["EN"],
+        "abstract": "QGIS is a powerful platform for geospatial work, but field data collection has always needed extra tooling. Mergin Maps closes that gap, giving teams a simple way to collect, sync and manage field data alongside QGIS. This talk covers what's changed over the past year, including the new webmaps capability which lets users preview, share and export collected data directly from a browser.",
+        "duration": 20,
+        "tags": ["QGIS", "Mergin Maps", "Field data", "Tools"]
+      },
+      {
+        "track": "track_3",
+        "title": "Data Quality: utiliser le potentiel géographique",
+        "speakers": [{ "name": "Vandy Berten", "organization": "Smals" }],
+        "languages": ["FR"],
+        "abstract": "N'importe quelle source de données pose des problèmes de qualité. Il existe de nombreuses méthodes, généralement basées sur des comparaisons de chaînes de caractères, pour détecter et traiter les problèmes dans les bases de données relationnelles classiques. Mais exploiter les données géographiques comme des points ou des polygones avec des techniques d'analytique spatiale permet d'identifier des erreurs impossible à détecter avec des méthodes classiques. Pour illustrer ces méthodes, nous partons des données de BeSt Address avec des librairies Python Open Source (geopandas, shapely…).",
+        "duration": 20,
+        "tags": ["Data Quality", "BeSt Address", "Python", "Spatial Analytics"]
+      }
+    ]
+  },
+  {
+    "time": "10:30",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "GeoSearch, le nouveau geocoder développé par l'IGN",
+        "speakers": [{ "name": "Florence Masson", "organization": "Institut Géographique National" }],
+        "languages": ["FR"],
+        "abstract": "L'Institut Géographique National (IGN) a récemment développé un nouvel outil de géocodage GeoSearch, actuellement disponible gratuitement. GeoSearch permet d'effectuer des recherches d'adresses à partir de BeSt Address, la source authentique des adresses en Belgique. L'outil intègre par ailleurs les données cadastrales ainsi que la toponymie de l'IGN, et offre également la possibilité de rechercher des bornes kilométriques.",
+        "duration": 20,
+        "tags": ["API", "WebGIS", "Geocoding", "IGN", "BeSt Address"]
+      },
+      {
+        "track": "track_2",
+        "title": "The earth is not flat! Introduction to processing with spherical geometries",
+        "speakers": [{ "name": "Joris Van den Bossche", "organization": null }],
+        "languages": ["EN"],
+        "abstract": "Not all geospatial data are best represented using a projected coordinate system. Unfortunately, when using open-source geoprocessing software, this is often based on the assumption of having projected geometries. This presentation will introduce the problem and showcase the limitations of assuming projected coordinates, then present tools that handle spherical geometries out of the box (R sf, duckdb geography extension), and introduce Spherely: a new Python library that fills this gap, aiming to provide a similar API as Shapely but for geometries on the sphere.",
+        "duration": 20,
+        "tags": ["Python", "Spherical geometries", "Shapely", "Tools"]
+      },
+      {
+        "track": "track_3",
+        "title": "Pushing the boundaries: Automated Geometry Alignment with 'brdr' and 'brdrQ'",
+        "speakers": [{ "name": "Karel Dieussaert", "organization": "GeoSquare" }],
+        "languages": ["EN"],
+        "abstract": "Maintaining spatial consistency between thematic geographic datasets and reference layers (such as cadastral parcels) is a persistent challenge in GIS workflows. Athumi and the Flanders Heritage Agency developed brdr, an open-source Python library, and its companion QGIS plugin brdrQ, to automate geometry alignment to reference borders. By decoupling the alignment engine from the user interface, the tools serve both developers (pipeline integration) and GIS analysts (visual validation).",
+        "duration": 20,
+        "tags": ["Data Quality", "QGIS", "Python", "brdr", "Geometry"]
+      }
+    ]
+  },
+  {
+    "time": "11:00",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "BruWater: gegevens over oppervlaktewater en grondwater in het Brussels Gewest",
+        "speakers": [{ "name": "Elise Beke", "organization": "Leefmilieu Brussel" }],
+        "languages": ["NL"],
+        "abstract": "BruWater is een webapplicatie van Leefmilieu Brussel voor het raadplegen van de oppervlakte- en grondwatergegevens van het Brussels Hoofdstedelijk Gewest. Ontwikkeld door studiebureau open data script - Cartostation - Geodata van Leefmilieu Brussel. Via deze applicatie kan u de monitoringsgegevens over de waterkwaliteit van waterlopen, vijvers en grondwater en de waterstanden in de peilbuizen opzoeken, visualiseren en opvragen.",
+        "duration": 20,
+        "tags": ["API", "WebGIS", "Water", "Brussels", "Open Data"]
+      },
+      {
+        "track": "track_2",
+        "title": "State of MapServer",
+        "speakers": [{ "name": "Seth Girvin", "organization": "OSGeo" }],
+        "languages": ["EN"],
+        "abstract": "MapServer, a founding OSGeo project, is widely used for publishing spatial data and interactive web mapping applications. This talk provides an overview of the new 8.6 release and a preview of the upcoming 8.8 release, highlighting key enhancements and features. Integration with powerful new GDAL features, such as pipelines and cloud-native drivers, is demonstrated, along with results from the first-ever MapServer User Survey.",
+        "duration": 20,
+        "tags": ["MapServer", "OSGeo", "Tools", "GDAL"]
+      },
+      {
+        "track": "track_3",
+        "title": "RTTI Data Quality Parameters: What They Measure and Why They Matter",
+        "speakers": [{ "name": "Stéphanie Chaufton", "organization": "TISA" }],
+        "languages": ["EN"],
+        "abstract": "The RTTI 5-Star Rating Specification defines a common framework for assessing the quality of Real-Time Traffic Information (RTTI) data. It provides measurable quality requirements for three initial Priority Use Cases — Speed Limits, Roadworks, and Road Closures — and establishes a transparent basis for evaluating data. The standard evaluates datasets against quality parameters including availability, accessibility, accuracy, timeliness, completeness, consistency, and interoperability.",
+        "duration": 20,
+        "tags": ["Data Quality", "Traffic", "RTTI", "Standards", "DATEX II"]
+      }
+    ]
+  },
+  {
+    "time": "11:30",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "Flash Talks",
+        "speakers": [
+          { "name": "Elise Beke", "organization": null },
+          { "name": "Sébastien Defrance", "organization": null },
+          { "name": "Manuel Claeys Bouuaert", "organization": null },
+          { "name": "Gabriel Bolbotina", "organization": null },
+          { "name": "An Heirman", "organization": null },
+          { "name": "Raymond Nijssen", "organization": null }
+        ],
+        "languages": ["NL", "FR", "EN"],
+        "abstract": "6 presentations (2 min.) :\n\n1. Kaart van de ondoorlatende oppervlakken van het Brussels Gewest\n2. Un enjeu de mobilité douce et de résilience urbaine\n3. Topotijdreis.be\n4. Web maps : partager vos cartes en quelques clics\n5. Achter de schermen van het Nationaal Geo Register: GeoNetwork op nationale schaal\n6. Molenbiotopen",
+        "duration": 30,
+        "tags": ["Flash Talk"]
+      },
+      {
+        "track": "track_2",
+        "title": "Le rendu, la donnée, et l'argent du beurre. Panorama 2026 des tuiles vectorielles",
+        "speakers": [{ "name": "Marc Ducobu", "organization": "WAPY" }],
+        "languages": ["EN"],
+        "abstract": "Les tuiles vectorielles permettent de servir la donnée et de maîtriser le rendu côté client, sans choisir entre les deux. Nous reviendrons sur le principe, puis sur l'actualité : MLT, le successeur du format MVT annoncé début 2026, l'usage (web mapping et support dans QGIS), et finalement sur les méthodes pour produire ses propres tuiles.",
+        "duration": 20,
+        "tags": ["Tools", "Vector Tiles", "MVT", "QGIS", "Web Mapping"]
+      },
+      {
+        "track": "track_3",
+        "title": "When a Polygon Changes: Geospatial Data Processing at Scale — A Zadu Case Study",
+        "speakers": [{ "name": "Jeroen Stiers", "organization": "GIM — Smart Geo Insights" }],
+        "languages": ["EN"],
+        "abstract": "Zadu brings together large volumes of geospatial data from different sources and transforms them into a consistent and up-to-date data product. This talk presents the overall architecture behind this processing pipeline, combining Python, Prefect, PostGIS, QGIS, DuckDB and Parquet. We show how quarterly large-scale data processing and daily address updates follow different workflows, while ultimately feeding the same data product.",
+        "duration": 20,
+        "tags": ["Data Quality", "PostGIS", "Python", "DuckDB", "Architecture"]
+      }
+    ]
+  },
+  {
+    "time": "12:00",
+    "event": {
+      "title": "Lunch",
+      "speakers": [],
+      "type": "break"
+    }
+  },
+  {
+    "time": "13:00",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "Quantitative Ecology Meets the High Street: Using Biodiversity Metrics to Assess Multiscale Retail Structure in Brussels",
+        "speakers": [{ "name": "Hugo Colicchia", "organization": "Université libre de Bruxelles" }],
+        "languages": ["FR"],
+        "abstract": "Traditional measures of spatial distribution typically rely on discrete spatial units and suffer from the well-known Modifiable Areal Unit Problem (MAUP). Drawing on the recent work of Marcon and Puech (2025), who proposed a set of local measures of biodiversity, this talk shows that such metrics can also be used to assess retail structure across scales, taking Brussels as a case study.",
+        "duration": 20,
+        "tags": ["Use Cases", "Brussels", "Ecology", "Spatial Analysis"]
+      },
+      {
+        "track": "track_2",
+        "title": "Mapping cycling infrastructure in OpenStreetMap",
+        "speakers": [{ "name": "Seppe Santens", "organization": "Westtoer" }],
+        "languages": ["EN"],
+        "abstract": "Good cycling infrastructure data is essential for modern mobility analysis. In this hands-on workshop, we dive into mapping cycling infrastructure in OSM and re-using that data. We deconstruct the tagging scheme, use Overpass Turbo to pinpoint missing or inconsistent bicycle data, get hands-on with the iD editor or JOSM, and learn how to query OSM data and export for analysis in your GIS tool of choice. (Workshop — 90 min)",
+        "duration": 90,
+        "tags": ["Workshop", "OpenStreetMap", "Cycling", "Overpass Turbo", "iD editor"]
+      },
+      {
+        "track": "track_3",
+        "title": "From field to map: Collaborative data collection with QGIS & Mergin Maps",
+        "speakers": [{ "name": "Tomas Mizera", "organization": "Mergin Maps" }],
+        "languages": ["EN"],
+        "abstract": "Mergin Maps is a collaborative data collection system built for QGIS. In this workshop, we put Mergin Maps into practice: prepare a data collection project in QGIS, collect data together as a team, then explore the new webmaps capability. Bring a laptop with QGIS installed. A Mergin Maps account is recommended (free at merginmaps.com). (Workshop — 90 min)",
+        "duration": 90,
+        "tags": ["Workshop", "QGIS", "Mergin Maps", "Field Data", "Webmaps"]
+      }
+    ]
+  },
+  {
+    "time": "13:30",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "J-emma.com — Genèse d'une archive en mouvement",
+        "speakers": [{ "name": "Pacôme Béru", "organization": "Atelier Cartographique" }],
+        "languages": ["FR"],
+        "abstract": "J-emma.com est une plateforme cartographique dédiée à l'organisation et la consultation d'une archive sur l'histoire du bâti de la médina de Marrakech. Nous présenterons la méthodologie mise en place pour accompagner la genèse du projet et le géo-référencement des documents, ainsi que les éléments clés de la plateforme de visualisation. La plateforme combine Nextcloud, des développements dédiés (Rust, OpenLayers, HTML, CSS) et QGIS pour la création de fonds de plans à base de données OSM, d'orthophotos et de traitement de DEM.",
+        "duration": 20,
+        "tags": ["Use Cases", "Archive", "OpenLayers", "QGIS", "OSM"]
+      }
+    ]
+  },
+  {
+    "time": "14:00",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "A web application for simulating erosion in Wallonia, with a focus on topography",
+        "speakers": [{ "name": "Julien Minet", "organization": "Champs Libres Coopérative" }],
+        "languages": ["FR"],
+        "abstract": "We present a new web application for simulating erosion in Wallonia, part of the Intell'eau research project (UCLouvain, GxABT, SPW). The application is based on the MapLibre framework and includes a 3D mode using a digital elevation model of Wallonia at 5-metre resolution, resulting in high-resolution landscape views. It allows users to simulate erosion in agricultural lands and analyse how crop adaptation can mitigate erosion risk.",
+        "duration": 20,
+        "tags": ["Use Cases", "MapLibre", "3D", "Erosion", "Wallonia"]
+      }
+    ]
+  },
+  {
+    "time": "14:30",
+    "event": {
+      "title": "Coffee Break",
+      "speakers": [],
+      "type": "break"
+    }
+  },
+  {
+    "time": "15:00",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "… from Groene Hond to Palais Stoclet, a Geo-MCP for Brussels",
+        "speakers": [{ "name": "Ruben Cappelle", "organization": "Brussels Mobility" }],
+        "languages": ["NL"],
+        "abstract": "How can a chatbot understand spatial references such as \"between Groene Hond and Palais Stoclet\" or \"near the European Quarter\"? Converting these informal descriptions into precise geometries remains a key challenge. This presentation introduces a Geo-MCP developed for Brussels: how a reference database of landmarks and place names is built, how spatial descriptions are detected and resolved, and how they are transformed into GIS-ready geometries. The MCP can be connected to chat interfaces, allowing users to query geospatial datasets through natural language.",
+        "duration": 20,
+        "tags": ["GeoAI", "AI", "Brussels", "NLP", "MCP"]
+      },
+      {
+        "track": "track_2",
+        "title": "How to get nice geographic data from OpenStreetMap in Belgium?",
+        "speakers": [{ "name": "Julien Minet", "organization": "Champs Libres Coopérative" }],
+        "languages": ["EN"],
+        "abstract": "OpenStreetMap (OSM) is a collaborative map of the world, increasingly recognised as an awesome source of geographic data. In this workshop, we focus on the state of OSM data in Belgium: what can be found in OSM, how to get the data, what is its quality, and what is the situation in Belgium? We go through thematic data (road, building, land-use, infrastructure) and look at their state. Targeted at anyone who would like to use OSM data in their process. (Workshop — 90 min)",
+        "duration": 90,
+        "tags": ["Workshop", "OpenStreetMap", "Belgium", "Data Quality"]
+      },
+      {
+        "track": "track_3",
+        "title": "Working title: (Poverty) Cycle Infrastructure in Flanders",
+        "speakers": [
+          { "name": "Vivien van Dongen", "organization": null },
+          { "name": "Emma Duymelinck", "organization": "Vlaamse Overheid — MOW" }
+        ],
+        "languages": ["EN"],
+        "abstract": "A printed pamphlet map on A2 format — a bivariate choropleth map displaying bicycle access in comparison to administrative poverty risk. The map covers Flanders and serves as food for thought for socio-economic mobility access across societal levels, overlaid with the Flemish cycling infrastructure. Inspired by critical cartography to discuss underlying power dynamics and mobility poverty. Using QGIS and Inkscape with Flemish open data. (Workshop — 90 min)",
+        "duration": 90,
+        "tags": ["Workshop", "Cartography", "QGIS", "Inkscape", "Cycling", "Flanders"]
+      }
+    ]
+  },
+  {
+    "time": "15:30",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "From Orthophotos to Objects: Building a GeoAI Change-Detection Pipeline with Open-Source Tools at NGI",
+        "speakers": [{ "name": "Jérôme Servais", "organization": "NGI — IGN" }],
+        "languages": ["FR"],
+        "abstract": "Every new aerial survey captures changes that take time to reach the map. Our GeoAI project uses open-source deep learning to detect topographic objects and changes automatically from aerial orthophotos. This talk presents the pipeline: from orthophoto to trained model, inference, post-processing, and integration into the database and quality-control chain. Built on YOLO/Ultralytics and the Segment Anything Model, and developed in collaboration with Kadaster NL. The \"cartographer in the loop\" remains central by design.",
+        "duration": 20,
+        "tags": ["GeoAI", "AI", "IGN", "Deep Learning", "Change Detection", "YOLO"]
+      }
+    ]
+  },
+  {
+    "time": "16:00",
+    "talks": [
+      {
+        "track": "track_1",
+        "title": "From cobwebs to web: creating open-access digital archives with (open-source) GeoAI",
+        "speakers": [{ "name": "Emma Duymelinck", "organization": "Vlaamse Overheid — MOW" }],
+        "languages": ["NL"],
+        "abstract": "For years, 20th-century photographs from aerial surveys for public works have been in storage, containing a unique record of how Flanders looked decades ago. The Flemish Department of Mobility and Public Works explains the workflow to turn tens of thousands of aerial images from the 1950s into accurately georeferenced images. A custom MapStore application brings the pieces together, allowing users to explore thousands of images through metadata, spatial filters and map-based previews. A pragmatic approach to FOSS in a public-sector context.",
+        "duration": 20,
+        "tags": ["GeoAI", "AI", "Archives", "MapStore", "Flanders", "FOSS"]
+      }
+    ]
+  },
+  {
+    "time": "16:30",
+    "event": {
+      "title": "Coffee Break",
+      "speakers": [],
+      "type": "break"
+    }
+  },
+  {
+    "time": "17:00",
+    "event": {
+      "title": "FORUM — OSGeo.be in Action: Activities & FOSS4G Belgium User Groups",
+      "speakers": [
+        { "name": "Raymond Nijssen", "organization": "QGIS Gebruikersgroep Nederland" }
+      ],
+      "type": "meeting",
+      "abstract": "Community forum covering OSGeo.be activities and Belgian FOSS4G user groups (QGIS, PostgreSQL, OSM, GRASS…). Includes a flash talk by Raymond Nijssen: \"Where is the QGIS User Group Belgium?\" — sharing the story from the Dutch User Group and discussing the creation of a Belgian chapter.",
+      "tags": ["Community", "OSGeo", "QGIS", "Forum"]
+    }
+  },
+  {
+    "time": "18:00",
+    "event": {
+      "title": "Closing Speech",
+      "speakers": [],
+      "type": "keynote"
+    }
+  }
+]

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "head": {
     "title": "FOSS4G Belgium 2026",
     "subtitle": "Brussels, 15 October 2026"
@@ -35,7 +35,7 @@
     },
     "getYourTickets": "Registration coming soon",
     "registration": {
-      "title": "Free entry — registration required",
+      "title": "Free entry â€” registration required",
       "free": {
         "title": "Free participation",
         "content": "The conference is entirely free. Registration is however required for logistical reasons (capacity, catering, badges).",
@@ -43,7 +43,7 @@
       },
       "attestation": {
         "title": "Training certificate",
-        "content": "Need an attendance certificate? This is possible through an organisational sponsoring mechanism (€100).",
+        "content": "Need an attendance certificate? This is possible through an organisational sponsoring mechanism (â‚¬100).",
         "contact": "Contact board@osgeo.be",
         "contactUrl": "mailto:board@osgeo.be"
       },
@@ -94,7 +94,7 @@
       "title": "Our Channels",
       "mailingLabel": "Main discussion",
       "chatLabel": "Real-time chat",
-      "matrixNote": "New to Matrix? Create a free account in 2 min — the room opens directly in your browser, no install needed."
+      "matrixNote": "New to Matrix? Create a free account in 2 min â€” the room opens directly in your browser, no install needed."
     },
     "resources": {
       "title": "Web Resources"
@@ -107,7 +107,7 @@
     }
   },
   "maps": {
-    "title": "Call for Maps — Map Gallery",
+    "title": "Call for Maps â€” Map Gallery",
     "content": "The Maps Competition has been a highlight of FOSS4G Belgium since 2022. Submit your map made with open source tools and see it displayed at the conference.",
     "tradition": {
       "title": "A FOSS4G Belgium Tradition",
@@ -115,9 +115,9 @@
     },
     "criteria": {
       "title": "Submission Criteria",
-      "software": "Map made entirely with open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscape…)",
+      "software": "Map made entirely with open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscapeâ€¦)",
       "resolution": "High-resolution file: PNG or PDF, minimum 300 dpi, A2 or A1 format",
-      "theme": "Any theme accepted: urban, environment, history, transport, art, open data…",
+      "theme": "Any theme accepted: urban, environment, history, transport, art, open dataâ€¦",
       "legend": "A legend and a title are required",
       "description": "A short description (max 150 words) stating the tools used"
     },
@@ -229,7 +229,7 @@
     }
   },
   "volunteer": {
-    "title": "Call for Volunteers — FOSS4G Belgium 2026",
+    "title": "Call for Volunteers â€” FOSS4G Belgium 2026",
     "content": "FOSS4G Belgium runs on community energy. Join the volunteer team and help make 15 October 2026 happen at Tour & Taxis, Brussels.",
     "contactUs": "Contact Us",
     "perks": {
@@ -276,17 +276,17 @@
       "opensDate": "7 July 2026",
       "opensLabel": "Online volunteer registrations open",
       "meetup1Date": "4 June 2026",
-      "meetup1Label": "In-person meetup — Cercle des Voyageurs, Brussels (from 6 pm)",
+      "meetup1Label": "In-person meetup â€” Cercle des Voyageurs, Brussels (from 6 pm)",
       "meetup2Date": "3 September 2026",
-      "meetup2Label": "In-person meetup — Cercle des Voyageurs, Brussels (from 6 pm)",
+      "meetup2Label": "In-person meetup â€” Cercle des Voyageurs, Brussels (from 6 pm)",
       "briefingDate": "10 October 2026",
       "briefingLabel": "Online briefing",
       "eventDate": "15 October 2026",
-      "eventLabel": "Volunteer day — Tour & Taxis, Brussels"
+      "eventLabel": "Volunteer day â€” Tour & Taxis, Brussels"
     },
     "apply": {
       "title": "Get involved now",
-      "content": "No deadline — join the mailing list or the OSGeo Belgium Matrix channel to follow requests in real time and express your interest.",
+      "content": "No deadline â€” join the mailing list or the OSGeo Belgium Matrix channel to follow requests in real time and express your interest.",
       "matrixLabel": "Join Matrix #osgeo-be",
       "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
     }
@@ -343,7 +343,7 @@
       "coSponsorLunch": "(Co-)sponsor of the lunch in your name",
       "booth": "Exhibition booth",
       "dedicatedPost": "Dedicated social media post",
-      "miniPresentation": "Optional mini-talk (2–3 min): your open source commitment in Belgium",
+      "miniPresentation": "Optional mini-talk (2â€“3 min): your open source commitment in Belgium",
       "tshirtGift": "OSGeo Belgium t-shirt as a gift",
       "stickersGift": "FOSS4G 2026 stickers as a gift",
       "logoOnFoss4g": "Logo on foss4g.be",
@@ -357,22 +357,22 @@
     "tiers": {
       "gold": {
         "title": "Gold",
-        "price": "€1,200",
+        "price": "â‚¬1,200",
         "cta": "Become a Gold Sponsor"
       },
       "silver": {
         "title": "Silver",
-        "price": "€500",
+        "price": "â‚¬500",
         "cta": "Become a Silver Sponsor"
       },
       "bronze": {
         "title": "Bronze",
-        "price": "€250",
+        "price": "â‚¬250",
         "cta": "Become a Bronze Sponsor"
       },
       "community": {
         "title": "Community",
-        "price": "€100",
+        "price": "â‚¬100",
         "description": "Ideal for surveyors, independent consultants and companies wishing to support the event via their training budget.",
         "cta": "Register as a Community Sponsor"
       }
@@ -393,7 +393,7 @@
   },
   "schedule": {
     "title": "Program",
-    "subtitle": "15 October 2026 • Brussels, Belgium",
+    "subtitle": "15 October 2026 â€¢ Brussels, Belgium",
     "stats": {
       "presentations": "Presentations",
       "speakers": "Speakers",
@@ -405,9 +405,9 @@
     },
     "filters": {
       "allTracks": "All Tracks",
-      "track1": "Room 1",
-      "track2": "Room 2",
-      "track3": "Room 3",
+      "track1": "Agora",
+      "track2": "Sylva",
+      "track3": "Aqua",
       "talksOnly": "Talks only"
     },
     "upcoming": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,13 +1,13 @@
-{
+﻿{
   "head": {
     "title": "FOSS4G Belgique 2026",
     "subtitle": "Bruxelles, 15 octobre 2026"
   },
   "nav": {
     "home": "Accueil",
-    "about": "À propos",
-    "callForPresentations": "Appel à présentations",
-    "callForMaps": "Présentez votre carte",
+    "about": "Ã€ propos",
+    "callForPresentations": "Appel Ã  prÃ©sentations",
+    "callForMaps": "PrÃ©sentez votre carte",
     "schedule": "Programme",
     "ourSponsors": "Nos sponsors",
     "becomeSponsor": "Devenir sponsor",
@@ -18,45 +18,45 @@
   },
   "index": {
     "about": {
-      "title": "À propos de FOSS4G",
-      "teaser": "Rejoignez-nous le 15 octobre 2026 à Bruxelles pour une conférence d'une journée avec discours, ateliers pratiques et réseautage autour des outils géospatiaux open-source.",
+      "title": "Ã€ propos de FOSS4G",
+      "teaser": "Rejoignez-nous le 15 octobre 2026 Ã  Bruxelles pour une confÃ©rence d'une journÃ©e avec discours, ateliers pratiques et rÃ©seautage autour des outils gÃ©ospatiaux open-source.",
       "features": {
-        "keynotes": "Discours & Présentations",
-        "networking": "Réseautage Communautaire",
+        "keynotes": "Discours & PrÃ©sentations",
+        "networking": "RÃ©seautage Communautaire",
         "osgeoTools": "Outils OSGEO"
       },
       "learnMore": "En savoir plus"
     },
     "goldSponsors": {
-      "thanksTo": "Merci à nos",
+      "thanksTo": "Merci Ã  nos",
       "goldSponsors": "sponsors or",
-      "whoSupportUs": "qui supportent notre événement.",
-      "showAllSponsors": "Découvrez tous nos sponsors"
+      "whoSupportUs": "qui supportent notre Ã©vÃ©nement.",
+      "showAllSponsors": "DÃ©couvrez tous nos sponsors"
     },
-    "getYourTickets": "Inscriptions bientôt disponibles",
+    "getYourTickets": "Inscriptions bientÃ´t disponibles",
     "registration": {
-      "title": "Entrée libre — inscription obligatoire",
+      "title": "EntrÃ©e libre â€” inscription obligatoire",
       "free": {
         "title": "Participation gratuite",
-        "content": "La conférence est entièrement gratuite. Une inscription préalable est cependant requise pour des raisons logistiques (capacité, catering, badges).",
-        "opensNote": "Inscriptions ouvertes en septembre 2026, une fois le programme publié."
+        "content": "La confÃ©rence est entiÃ¨rement gratuite. Une inscription prÃ©alable est cependant requise pour des raisons logistiques (capacitÃ©, catering, badges).",
+        "opensNote": "Inscriptions ouvertes en septembre 2026, une fois le programme publiÃ©."
       },
       "attestation": {
         "title": "Attestation de formation",
-        "content": "Besoin d'une attestation pour votre participation ? C'est possible via un mécanisme de sponsoring organisationnel (100 €).",
+        "content": "Besoin d'une attestation pour votre participation ? C'est possible via un mÃ©canisme de sponsoring organisationnel (100 â‚¬).",
         "contact": "Contacter board@osgeo.be",
         "contactUrl": "mailto:board@osgeo.be"
       },
-      "legalNote": "Conformément aux conditions du lieu, aucun droit d'entrée n'est perçu. Tout soutien financier passe exclusivement par le sponsoring organisationnel.",
+      "legalNote": "ConformÃ©ment aux conditions du lieu, aucun droit d'entrÃ©e n'est perÃ§u. Tout soutien financier passe exclusivement par le sponsoring organisationnel.",
       "mailing": {
         "title": "Mailing list",
-        "content": "Soyez notifié(e) par email dès l'ouverture des inscriptions.",
-        "label": "S'inscrire à la mailing list",
+        "content": "Soyez notifiÃ©(e) par email dÃ¨s l'ouverture des inscriptions.",
+        "label": "S'inscrire Ã  la mailing list",
         "url": "https://lists.osgeo.org/cgi-bin/mailman/listinfo/belgium"
       },
       "pretix": {
         "title": "Liste d'attente Pretix",
-        "content": "Recevez un lien personnel dès l'ouverture officielle.",
+        "content": "Recevez un lien personnel dÃ¨s l'ouverture officielle.",
         "label": "Rejoindre la liste d'attente",
         "url": "https://pretix.eu/osgeobe/foss4gbe/"
       }
@@ -70,63 +70,63 @@
     },
     "mission": {
       "title": "Notre mission",
-      "content": "La foundation OSGeo est une organisation à but non lucratif dont la mission est de soutenir le développement de logiciels géospatiaux open source et de promouvoir leur utilisation. La fondation fournit un soutien financier, organisationnel et juridique à la communauté géospatiale open source au sens large."
+      "content": "La foundation OSGeo est une organisation Ã  but non lucratif dont la mission est de soutenir le dÃ©veloppement de logiciels gÃ©ospatiaux open source et de promouvoir leur utilisation. La fondation fournit un soutien financier, organisationnel et juridique Ã  la communautÃ© gÃ©ospatiale open source au sens large."
     },
     "support": {
       "title": "Support",
-      "content": "Notre organisation sert d'entité juridique indépendante où les membres peuvent contribuer par du code, des financements et d'autres ressources, assurant la préservation des contributions pour le bénéfice public. OSGeo agit aussi en tant qu'organisation de sensibilisation et de plaidoyer, offrant forum et infrastructure partagée pour renforcer la collaboration entre projets."
+      "content": "Notre organisation sert d'entitÃ© juridique indÃ©pendante oÃ¹ les membres peuvent contribuer par du code, des financements et d'autres ressources, assurant la prÃ©servation des contributions pour le bÃ©nÃ©fice public. OSGeo agit aussi en tant qu'organisation de sensibilisation et de plaidoyer, offrant forum et infrastructure partagÃ©e pour renforcer la collaboration entre projets."
     },
     "events": {
-      "title": "Événements FOSS4G Belgium",
-      "content": "Une des activités principales de l'OSGeo Belgium est l'organisation d'événements rassemblant la communauté géospatiale open source en Belgique. Notre événement le plus important est le FOSS4G Belgium."
+      "title": "Ã‰vÃ©nements FOSS4G Belgium",
+      "content": "Une des activitÃ©s principales de l'OSGeo Belgium est l'organisation d'Ã©vÃ©nements rassemblant la communautÃ© gÃ©ospatiale open source en Belgique. Notre Ã©vÃ©nement le plus important est le FOSS4G Belgium."
     },
     "projects": {
       "title": "Projets Open Source",
-      "content": "Les projets soutenus par la fondation OSGeo sont tous librement disponibles et utilisables sous une licence open source certifiée par l'OSI. Ces projets incluent des logiciels géospatiaux populaires tels que QGIS, GeoServer, PostGIS, et bien d'autres qui sont largement utilisés dans l'industrie."
+      "content": "Les projets soutenus par la fondation OSGeo sont tous librement disponibles et utilisables sous une licence open source certifiÃ©e par l'OSI. Ces projets incluent des logiciels gÃ©ospatiaux populaires tels que QGIS, GeoServer, PostGIS, et bien d'autres qui sont largement utilisÃ©s dans l'industrie."
     }
   },
   "contact": {
     "contactUs": "Contactez-nous",
-    "askByEmailTo": "Pour toute demande, vous pouvez nous envoyer un courriel à",
+    "askByEmailTo": "Pour toute demande, vous pouvez nous envoyer un courriel Ã ",
     "sendAnEmail": "Envoyer un email",
-    "followUs": "Réseaux sociaux",
+    "followUs": "RÃ©seaux sociaux",
     "channels": {
       "title": "Nos canaux",
       "mailingLabel": "Discussion principale",
-      "chatLabel": "Chat en temps réel",
-      "matrixNote": "Nouveau sur Matrix ? Créez un compte gratuit en 2 min — le salon s'ouvre directement dans le navigateur, sans installation."
+      "chatLabel": "Chat en temps rÃ©el",
+      "matrixNote": "Nouveau sur Matrix ? CrÃ©ez un compte gratuit en 2 min â€” le salon s'ouvre directement dans le navigateur, sans installation."
     },
     "resources": {
       "title": "Ressources web"
     },
     "member": {
       "title": "Devenez membre",
-      "content": "Rejoignez OSGeo Belgium en vous inscrivant sur notre mailing list. L'adhésion est ouverte à tous, gratuitement.",
-      "cta": "S'inscrire à la mailing list",
-      "note": "La mailing list est notre canal de communication principal. Vous recevrez des informations sur nos événements et pourrez participer aux discussions."
+      "content": "Rejoignez OSGeo Belgium en vous inscrivant sur notre mailing list. L'adhÃ©sion est ouverte Ã  tous, gratuitement.",
+      "cta": "S'inscrire Ã  la mailing list",
+      "note": "La mailing list est notre canal de communication principal. Vous recevrez des informations sur nos Ã©vÃ©nements et pourrez participer aux discussions."
     }
   },
   "maps": {
-    "title": "Call for Maps — Galerie cartographique",
-    "content": "La Maps Competition est un rendez-vous incontournable de FOSS4G Belgium depuis 2022. Soumettez votre carte réalisée avec des logiciels libres et voyez-la exposée lors de la conférence.",
+    "title": "Call for Maps â€” Galerie cartographique",
+    "content": "La Maps Competition est un rendez-vous incontournable de FOSS4G Belgium depuis 2022. Soumettez votre carte rÃ©alisÃ©e avec des logiciels libres et voyez-la exposÃ©e lors de la confÃ©rence.",
     "tradition": {
       "title": "Une tradition FOSS4G Belgium",
-      "content": "Depuis 2022, les participants soumettent des cartes réalisées avec des logiciels libres. Les meilleures sont sélectionnées, imprimées en grand format et exposées tout au long de la journée de conférence."
+      "content": "Depuis 2022, les participants soumettent des cartes rÃ©alisÃ©es avec des logiciels libres. Les meilleures sont sÃ©lectionnÃ©es, imprimÃ©es en grand format et exposÃ©es tout au long de la journÃ©e de confÃ©rence."
     },
     "criteria": {
-      "title": "Critères de soumission",
-      "software": "Carte réalisée entièrement avec des logiciels libres (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscape…)",
-      "resolution": "Fichier haute résolution : PNG ou PDF, minimum 300 dpi, format A2 ou A1",
-      "theme": "Tout thème accepté : urbain, environnement, histoire, transport, art, données ouvertes…",
-      "legend": "Une légende et un titre sont requis",
-      "description": "Une courte description (150 mots max) indiquant les outils utilisés"
+      "title": "CritÃ¨res de soumission",
+      "software": "Carte rÃ©alisÃ©e entiÃ¨rement avec des logiciels libres (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscapeâ€¦)",
+      "resolution": "Fichier haute rÃ©solution : PNG ou PDF, minimum 300 dpi, format A2 ou A1",
+      "theme": "Tout thÃ¨me acceptÃ© : urbain, environnement, histoire, transport, art, donnÃ©es ouvertesâ€¦",
+      "legend": "Une lÃ©gende et un titre sont requis",
+      "description": "Une courte description (150 mots max) indiquant les outils utilisÃ©s"
     },
-    "intentNote": "Marquez votre intention avant le 15 septembre afin que nous puissions réserver l'espace nécessaire dans la galerie.",
+    "intentNote": "Marquez votre intention avant le 15 septembre afin que nous puissions rÃ©server l'espace nÃ©cessaire dans la galerie.",
     "selection": {
-      "title": "Sélection et exposition",
-      "committee": "Sélection par le comité d'organisation début octobre",
-      "print": "Cartes sélectionnées imprimées en grand format",
-      "display": "Exposition tout au long de la journée du 15 octobre",
+      "title": "SÃ©lection et exposition",
+      "committee": "SÃ©lection par le comitÃ© d'organisation dÃ©but octobre",
+      "print": "Cartes sÃ©lectionnÃ©es imprimÃ©es en grand format",
+      "display": "Exposition tout au long de la journÃ©e du 15 octobre",
       "credit": "Mention des auteurs sur les cartes et dans le programme"
     },
     "timeline": {
@@ -134,50 +134,50 @@
       "opensDate": "7 juillet 2026",
       "opensLabel": "Ouverture des soumissions",
       "intentDate": "15 septembre 2026",
-      "intentLabel": "Date limite d'intention (réservation de l'espace)",
+      "intentLabel": "Date limite d'intention (rÃ©servation de l'espace)",
       "closesDate": "8 octobre 2026",
       "closesLabel": "Date limite de soumission",
       "selectionDate": "Mi-octobre 2026",
-      "selectionLabel": "Sélection par le comité",
+      "selectionLabel": "SÃ©lection par le comitÃ©",
       "eventDate": "15 octobre 2026",
-      "eventLabel": "Exposition à Tour & Taxis, Bruxelles"
+      "eventLabel": "Exposition Ã  Tour & Taxis, Bruxelles"
     },
     "submit": {
       "title": "Comment soumettre ?",
-      "content": "Le formulaire de soumission sera disponible ici dès le 7 juillet 2026. Inscrivez-vous à la mailing list pour être notifié(e) à l'ouverture.",
-      "mailingLabel": "S'inscrire à la mailing list",
+      "content": "Le formulaire de soumission sera disponible ici dÃ¨s le 7 juillet 2026. Inscrivez-vous Ã  la mailing list pour Ãªtre notifiÃ©(e) Ã  l'ouverture.",
+      "mailingLabel": "S'inscrire Ã  la mailing list",
       "mailingUrl": "https://lists.osgeo.org/cgi-bin/mailman/listinfo/belgium"
     }
   },
   "present": {
     "callToPresentations": {
-      "title": "Appel à propositions",
-      "teaser": "Contribuez au succès de l'édition 2026. FOSS4G Belgique aura lieu le 15 octobre 2026.",
+      "title": "Appel Ã  propositions",
+      "teaser": "Contribuez au succÃ¨s de l'Ã©dition 2026. FOSS4G Belgique aura lieu le 15 octobre 2026.",
       "opensLabel": "Ouverture :",
       "opensDate": "7 juillet 2026",
       "closesLabel": "Date limite :",
-      "closesDate": "25 août 2026"
+      "closesDate": "25 aoÃ»t 2026"
     },
     "formats": {
       "title": "Formats",
       "flash": {
         "title": "Flash talk",
         "duration": "2 minutes",
-        "desc": "Présenter brièvement un sujet de votre choix, une carte ou un poster"
+        "desc": "PrÃ©senter briÃ¨vement un sujet de votre choix, une carte ou un poster"
       },
       "presentation": {
-        "title": "Présentation",
+        "title": "PrÃ©sentation",
         "duration": "25 min (20 min + 5 min Q/R)",
-        "desc": "Présenter un sujet de manière approfondie"
+        "desc": "PrÃ©senter un sujet de maniÃ¨re approfondie"
       },
       "workshop": {
         "title": "Workshop",
-        "duration": "90 minutes (après-midi)",
-        "desc": "Session pratique initiant les participants à un logiciel, un plug-in, …"
+        "duration": "90 minutes (aprÃ¨s-midi)",
+        "desc": "Session pratique initiant les participants Ã  un logiciel, un plug-in, â€¦"
       }
     },
     "topics": {
-      "title": "Thématiques",
+      "title": "ThÃ©matiques",
       "osm": "OpenStreetMap - cartographie collaborative + Open Data",
       "postgresql": "PostgreSQL - PostGIS",
       "qgis": "QGIS + GRASS GIS",
@@ -185,43 +185,43 @@
       "other": "Autres sujets"
     },
     "submission": {
-      "title": "Modalités de soumission",
+      "title": "ModalitÃ©s de soumission",
       "intro": "Votre proposition doit inclure :",
       "fieldTitle": "Titre",
-      "fieldSummary": "Résumé (max 250 mots)",
-      "fieldWorkshop": "Si workshop : préciser les prérequis techniques pour les participants",
-      "fieldMaps": "Si carte ou poster : indiquer s'il doit être imprimé ou apporté par vous-même",
+      "fieldSummary": "RÃ©sumÃ© (max 250 mots)",
+      "fieldWorkshop": "Si workshop : prÃ©ciser les prÃ©requis techniques pour les participants",
+      "fieldMaps": "Si carte ou poster : indiquer s'il doit Ãªtre imprimÃ© ou apportÃ© par vous-mÃªme",
       "fieldLanguage": "Langue(s)",
       "fieldLevel": "Niveau",
-      "fieldFormat": "Format(s) souhaité(s) (plusieurs choix possibles)",
+      "fieldFormat": "Format(s) souhaitÃ©(s) (plusieurs choix possibles)",
       "formTitle": "Soumission des propositions",
-      "formIntro": "Les propositions doivent être déposées via le formulaire :",
+      "formIntro": "Les propositions doivent Ãªtre dÃ©posÃ©es via le formulaire :",
       "formLink": "Call for proposals | Framaforms.org",
       "formUrl": "https://framaforms.org/call-for-proposals-1780600203"
     },
     "criterias": {
-      "title": "Critères d'évaluation",
-      "quality": "Qualité des soumissions",
+      "title": "CritÃ¨res d'Ã©valuation",
+      "quality": "QualitÃ© des soumissions",
       "relevance": "Pertinence pour le public",
-      "program": "Cohérence avec le programme",
-      "note": "Le choix du comité de programme est définitif et sans appel. Les décisions du comité de programme ne reflètent l'opinion d'aucun employeur des membres."
+      "program": "CohÃ©rence avec le programme",
+      "note": "Le choix du comitÃ© de programme est dÃ©finitif et sans appel. Les dÃ©cisions du comitÃ© de programme ne reflÃ¨tent l'opinion d'aucun employeur des membres."
     },
     "timeline": {
       "title": "Calendrier",
       "opensDate": "7 juillet 2026",
       "opensLabel": "Ouverture des soumissions",
-      "closesDate": "25 août 2026",
+      "closesDate": "25 aoÃ»t 2026",
       "closesLabel": "Date limite de soumission",
       "notificationDate": "8 septembre 2026",
-      "notificationLabel": "Notification aux auteur·e·s",
+      "notificationLabel": "Notification aux auteurÂ·eÂ·s",
       "programDate": "15 septembre 2026",
-      "programLabel": "Programme publié",
+      "programLabel": "Programme publiÃ©",
       "eventDate": "15 octobre 2026",
-      "eventLabel": "Événement à Bruxelles"
+      "eventLabel": "Ã‰vÃ©nement Ã  Bruxelles"
     },
     "deadline": {
       "title": "Date limite",
-      "text": "La date limite de soumission est fixée au 25 août 2026, mais nous invitons à soumettre la proposition dès que possible. Les propositions seront évaluées par le Comité du programme et les auteurs seront informés si leur contribution a été acceptée. Toutes les propositions acceptées seront publiées sur le site de l'événement."
+      "text": "La date limite de soumission est fixÃ©e au 25 aoÃ»t 2026, mais nous invitons Ã  soumettre la proposition dÃ¨s que possible. Les propositions seront Ã©valuÃ©es par le ComitÃ© du programme et les auteurs seront informÃ©s si leur contribution a Ã©tÃ© acceptÃ©e. Toutes les propositions acceptÃ©es seront publiÃ©es sur le site de l'Ã©vÃ©nement."
     },
     "questions": {
       "title": "Des questions ?",
@@ -229,96 +229,96 @@
     }
   },
   "volunteer": {
-    "title": "Appel aux bénévoles — FOSS4G Belgium 2026",
-    "content": "FOSS4G Belgium repose sur l'énergie de sa communauté. Rejoignez l'équipe de bénévoles pour contribuer à l'organisation de la journée du 15 octobre 2026 à Bruxelles.",
+    "title": "Appel aux bÃ©nÃ©voles â€” FOSS4G Belgium 2026",
+    "content": "FOSS4G Belgium repose sur l'Ã©nergie de sa communautÃ©. Rejoignez l'Ã©quipe de bÃ©nÃ©voles pour contribuer Ã  l'organisation de la journÃ©e du 15 octobre 2026 Ã  Bruxelles.",
     "contactUs": "Nous contacter",
     "perks": {
       "title": "Ce que vous gagnez",
-      "tshirt": "T-shirt bénévole exclusif",
+      "tshirt": "T-shirt bÃ©nÃ©vole exclusif",
       "networking": "Rencontres avec les speakers et les participants",
-      "community": "Contribution directe à la communauté open source belge"
+      "community": "Contribution directe Ã  la communautÃ© open source belge"
     },
     "roles": {
       "title": "Postes disponibles",
       "reception": {
         "title": "Accueil & Badges",
-        "spots": "3 bénévoles",
-        "desc": "Accueil des participants à l'entrée et distribution du matériel"
+        "spots": "3 bÃ©nÃ©voles",
+        "desc": "Accueil des participants Ã  l'entrÃ©e et distribution du matÃ©riel"
       },
       "room": {
         "title": "Support en salle",
-        "spots": "4 à 6 bénévoles",
+        "spots": "4 Ã  6 bÃ©nÃ©voles",
         "desc": "Micro pendant les Q&A et signaux timing pour les orateurs"
       },
       "av": {
-        "title": "Technique audio/vidéo",
-        "spots": "2 bénévoles",
-        "desc": "Son, projection et gestion du streaming éventuel"
+        "title": "Technique audio/vidÃ©o",
+        "spots": "2 bÃ©nÃ©voles",
+        "desc": "Son, projection et gestion du streaming Ã©ventuel"
       },
       "social": {
-        "title": "Réseaux sociaux",
-        "spots": "1 à 2 bénévoles",
-        "desc": "Couverture de l'événement en temps réel sur les plateformes sociales"
+        "title": "RÃ©seaux sociaux",
+        "spots": "1 Ã  2 bÃ©nÃ©voles",
+        "desc": "Couverture de l'Ã©vÃ©nement en temps rÃ©el sur les plateformes sociales"
       },
       "maps": {
         "title": "Galerie de cartes & Expo",
-        "spots": "2 bénévoles",
+        "spots": "2 bÃ©nÃ©voles",
         "desc": "Installation et surveillance de la galerie de cartes"
       },
       "coordination": {
-        "title": "Coordination générale",
-        "spots": "1 à 2 bénévoles",
-        "desc": "Support à l'équipe organisatrice et résolution des imprévus"
+        "title": "Coordination gÃ©nÃ©rale",
+        "spots": "1 Ã  2 bÃ©nÃ©voles",
+        "desc": "Support Ã  l'Ã©quipe organisatrice et rÃ©solution des imprÃ©vus"
       }
     },
     "timeline": {
       "title": "Calendrier",
       "opensDate": "7 juillet 2026",
-      "opensLabel": "Ouverture des inscriptions bénévoles en ligne",
+      "opensLabel": "Ouverture des inscriptions bÃ©nÃ©voles en ligne",
       "meetup1Date": "4 juin 2026",
-      "meetup1Label": "Rencontre en présentiel — Cercle des Voyageurs, Bruxelles (dès 18h)",
+      "meetup1Label": "Rencontre en prÃ©sentiel â€” Cercle des Voyageurs, Bruxelles (dÃ¨s 18h)",
       "meetup2Date": "3 septembre 2026",
-      "meetup2Label": "Rencontre en présentiel — Cercle des Voyageurs, Bruxelles (dès 18h)",
+      "meetup2Label": "Rencontre en prÃ©sentiel â€” Cercle des Voyageurs, Bruxelles (dÃ¨s 18h)",
       "briefingDate": "10 octobre 2026",
       "briefingLabel": "Briefing en ligne",
       "eventDate": "15 octobre 2026",
-      "eventLabel": "Journée bénévole — Tour & Taxis, Bruxelles"
+      "eventLabel": "JournÃ©e bÃ©nÃ©vole â€” Tour & Taxis, Bruxelles"
     },
     "apply": {
       "title": "Comment s'impliquer maintenant",
-      "content": "Pas de date limite : inscrivez-vous à la mailing list ou rejoignez le salon Matrix OSGeo Belgium pour suivre les demandes en direct et manifester votre intérêt.",
+      "content": "Pas de date limite : inscrivez-vous Ã  la mailing list ou rejoignez le salon Matrix OSGeo Belgium pour suivre les demandes en direct et manifester votre intÃ©rÃªt.",
       "matrixLabel": "Rejoindre Matrix #osgeo-be",
       "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
     }
   },
   "cards": {
     "callForTopics": {
-      "title": "Appel à présentations",
-      "description": "Nous recherchons des présentations sur des sujets sur la thématique géospatial open-source. (Date limite: à préciser)",
-      "button": "Présenter"
+      "title": "Appel Ã  prÃ©sentations",
+      "description": "Nous recherchons des prÃ©sentations sur des sujets sur la thÃ©matique gÃ©ospatial open-source. (Date limite: Ã  prÃ©ciser)",
+      "button": "PrÃ©senter"
     },
     "schedulePreview": {
-      "comingSoon": "Bientôt disponible",
-      "title": "Aperçu du programme",
+      "comingSoon": "BientÃ´t disponible",
+      "title": "AperÃ§u du programme",
       "day1Label": "Jour 1 :",
-      "day1Items": "Accueil, Keynote, Déjeuner",
+      "day1Items": "Accueil, Keynote, DÃ©jeuner",
       "day2Label": "Jour 2 :",
-      "day2Items": "Ateliers, Présentations",
+      "day2Items": "Ateliers, PrÃ©sentations",
       "button": "Voir le programme complet"
     },
     "callForSponsors": {
       "title": "Devenez sponsor",
-      "description": "Soutenez FOSS4G Belgium 2026 et gagnez en visibilité au sein de la communauté géospatiale open-source.",
+      "description": "Soutenez FOSS4G Belgium 2026 et gagnez en visibilitÃ© au sein de la communautÃ© gÃ©ospatiale open-source.",
       "button": "Devenir sponsor"
     },
     "volunteers": {
       "title": "Aidez-nous!",
-      "description": "Mettez vos compétences et votre énergie au service du succès de FOSS4G Belgium 2026.",
+      "description": "Mettez vos compÃ©tences et votre Ã©nergie au service du succÃ¨s de FOSS4G Belgium 2026.",
       "button": "Participer"
     },
     "callForMaps": {
       "title": "Galerie de cartes",
-      "description": "Vous créez des cartes avec des outils open source ou des données ouvertes ? Soumettez votre travail à la Map Gallery.",
+      "description": "Vous crÃ©ez des cartes avec des outils open source ou des donnÃ©es ouvertes ? Soumettez votre travail Ã  la Map Gallery.",
       "button": "Soumettre une carte"
     }
   },
@@ -335,97 +335,97 @@
     "community": "Participants Community",
     "hero": {
       "title": "Soutenez FOSS4G Belgium 2026",
-      "description": "En sponsorisant FOSS4G Belgium, vous soutenez la communauté géospatiale open source belge et gagnez en visibilité auprès de ses membres."
+      "description": "En sponsorisant FOSS4G Belgium, vous soutenez la communautÃ© gÃ©ospatiale open source belge et gagnez en visibilitÃ© auprÃ¨s de ses membres."
     },
     "features": {
-      "logoOnFoss4gBig": "Logo (grand format) sur foss4g.be + bannière dans l'en-tête du site",
-      "logoInProgramHeader": "Logo dans l'en-tête du programme imprimé (A3/A0)",
-      "coSponsorLunch": "(Co-)sponsor du lunch à votre nom",
-      "booth": "Stand de présentation",
-      "dedicatedPost": "Post dédié sur les réseaux sociaux",
-      "miniPresentation": "Mini-présentation optionnelle (2–3 min) : votre engagement open source en Belgique",
+      "logoOnFoss4gBig": "Logo (grand format) sur foss4g.be + banniÃ¨re dans l'en-tÃªte du site",
+      "logoInProgramHeader": "Logo dans l'en-tÃªte du programme imprimÃ© (A3/A0)",
+      "coSponsorLunch": "(Co-)sponsor du lunch Ã  votre nom",
+      "booth": "Stand de prÃ©sentation",
+      "dedicatedPost": "Post dÃ©diÃ© sur les rÃ©seaux sociaux",
+      "miniPresentation": "Mini-prÃ©sentation optionnelle (2â€“3 min) : votre engagement open source en Belgique",
       "tshirtGift": "T-shirt OSGeo Belgium offert",
       "stickersGift": "Stickers FOSS4G 2026 offerts",
       "logoOnFoss4g": "Logo sur foss4g.be",
       "logoOnSponsorsPage": "Logo sur la page des sponsors",
-      "namedMomentSilver": "Co-sponsoring possible d'une pause café ou du verre de clôture (au choix)",
-      "smallBooth": "Petit stand de présentation",
-      "inProgramAtBreaks": "Repris dans le programme au niveau des pauses sponsorisées",
-      "socialMention": "Mention réseaux sociaux",
+      "namedMomentSilver": "Co-sponsoring possible d'une pause cafÃ© ou du verre de clÃ´ture (au choix)",
+      "smallBooth": "Petit stand de prÃ©sentation",
+      "inProgramAtBreaks": "Repris dans le programme au niveau des pauses sponsorisÃ©es",
+      "socialMention": "Mention rÃ©seaux sociaux",
       "officialInvoice": "Une facture officielle vous sera transmise"
     },
     "tiers": {
       "gold": {
         "title": "Gold",
-        "price": "1 200 €",
+        "price": "1 200 â‚¬",
         "cta": "Devenir sponsor Gold"
       },
       "silver": {
         "title": "Silver",
-        "price": "500 €",
+        "price": "500 â‚¬",
         "cta": "Devenir sponsor Silver"
       },
       "bronze": {
         "title": "Bronze",
-        "price": "250 €",
+        "price": "250 â‚¬",
         "cta": "Devenir sponsor Bronze"
       },
       "community": {
         "title": "Community",
-        "price": "100 €",
-        "description": "Idéal pour géomètres, consultants indépendants et entreprises souhaitant soutenir l'événement via leur budget formation.",
+        "price": "100 â‚¬",
+        "description": "IdÃ©al pour gÃ©omÃ¨tres, consultants indÃ©pendants et entreprises souhaitant soutenir l'Ã©vÃ©nement via leur budget formation.",
         "cta": "S'inscrire comme Community sponsor"
       }
     },
     "coc": {
       "title": "Code de conduite des sponsors",
-      "text": "Les sponsors de FOSS4G Belgium partagent les valeurs d'OSGeo : ouverture, collaboration et respect de la communauté. En devenant sponsor, vous vous engagez à respecter le <a href=\"https://www.osgeo.org/resources/osgeo-code-of-conduct/\" target=\"_blank\" rel=\"noopener\">Code de conduite OSGeo</a>. Les modalités détaillées seront précisées dans le dossier de sponsoring."
+      "text": "Les sponsors de FOSS4G Belgium partagent les valeurs d'OSGeo : ouverture, collaboration et respect de la communautÃ©. En devenant sponsor, vous vous engagez Ã  respecter le <a href=\"https://www.osgeo.org/resources/osgeo-code-of-conduct/\" target=\"_blank\" rel=\"noopener\">Code de conduite OSGeo</a>. Les modalitÃ©s dÃ©taillÃ©es seront prÃ©cisÃ©es dans le dossier de sponsoring."
     },
     "support": {
       "title": "Soutenez FOSS4G Belgium 2026",
-      "description": "Construisons ensemble la carte de la communauté géospatiale open source belge. Votre soutien rend l'événement possible et vous positionne au cœur de cet écosystème.",
+      "description": "Construisons ensemble la carte de la communautÃ© gÃ©ospatiale open source belge. Votre soutien rend l'Ã©vÃ©nement possible et vous positionne au cÅ“ur de cet Ã©cosystÃ¨me.",
       "cta": "Devenir Sponsor"
     },
     "footer": {
-      "thankYou": "Merci à nos sponsors",
+      "thankYou": "Merci Ã  nos sponsors",
       "subtext": "Votre soutien rend FOSS4G Belgium 2026 possible !"
     }
   },
   "schedule": {
     "title": "Programme",
-    "subtitle": "15 octobre 2026 • Bruxelles, Belgique",
+    "subtitle": "15 octobre 2026 â€¢ Bruxelles, Belgique",
     "stats": {
-      "presentations": "Présentations",
+      "presentations": "PrÃ©sentations",
       "speakers": "Orateurs",
       "tracks": "Pistes",
-      "duration": "Durée"
+      "duration": "DurÃ©e"
     },
     "search": {
-      "placeholder": "Rechercher des présentations, orateurs ou organisations..."
+      "placeholder": "Rechercher des prÃ©sentations, orateurs ou organisations..."
     },
     "filters": {
       "allTracks": "Toutes les Pistes",
-      "track1": "Salle 1",
-      "track2": "Salle 2",
-      "track3": "Salle 3",
-      "talksOnly": "Présentations seulement"
+      "track1": "Agora",
+      "track2": "Sylva",
+      "track3": "Aqua",
+      "talksOnly": "PrÃ©sentations seulement"
     },
     "upcoming": {
-      "upNext": "À venir à"
+      "upNext": "Ã€ venir Ã "
     },
     "expandable": {
-      "abstract": "Résumé",
+      "abstract": "RÃ©sumÃ©",
       "minutes": "minutes",
       "moreText": "plus"
     },
     "languages": {
       "english": "Anglais",
-      "french": "Français",
-      "dutch": "Néerlandais"
+      "french": "FranÃ§ais",
+      "dutch": "NÃ©erlandais"
     },
     "empty": {
-      "title": "Programme bientôt disponible",
-      "description": "Le programme de FOSS4G Belgium 2026 sera annoncé prochainement."
+      "title": "Programme bientÃ´t disponible",
+      "description": "Le programme de FOSS4G Belgium 2026 sera annoncÃ© prochainement."
     }
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,6 +1,6 @@
-{
+﻿{
   "head": {
-    "title": "FOSS4G Belgïe 2026",
+    "title": "FOSS4G BelgÃ¯e 2026",
     "subtitle": "Brussel, 15 oktober 2026"
   },
   "nav": {
@@ -35,7 +35,7 @@
     },
     "getYourTickets": "Inschrijvingen binnenkort beschikbaar",
     "registration": {
-      "title": "Vrije toegang — inschrijving verplicht",
+      "title": "Vrije toegang â€” inschrijving verplicht",
       "free": {
         "title": "Gratis deelname",
         "content": "De conferentie is volledig gratis. Een voorafgaande inschrijving is echter vereist om logistieke redenen (capaciteit, catering, badges).",
@@ -43,11 +43,11 @@
       },
       "attestation": {
         "title": "Opleidingsattest",
-        "content": "Heeft u een aanwezigheidsattest nodig? Dat kan via een organisatorisch sponsormechanisme (€100).",
+        "content": "Heeft u een aanwezigheidsattest nodig? Dat kan via een organisatorisch sponsormechanisme (â‚¬100).",
         "contact": "Contact board@osgeo.be",
         "contactUrl": "mailto:board@osgeo.be"
       },
-      "legalNote": "Conform de voorwaarden van de locatie wordt geen toegangsprijs aangerekend. Alle financiële steun verloopt uitsluitend via organisatorische sponsoring.",
+      "legalNote": "Conform de voorwaarden van de locatie wordt geen toegangsprijs aangerekend. Alle financiÃ«le steun verloopt uitsluitend via organisatorische sponsoring.",
       "mailing": {
         "title": "Mailinglijst",
         "content": "Word per e-mail verwittigd zodra de inschrijvingen openen.",
@@ -70,7 +70,7 @@
     },
     "mission": {
       "title": "Onze Missie",
-      "content": "OSGeo is een non-profitorganisatie die zich richt op het ondersteunen van de ontwikkeling van open-source geospatiale software en het bevorderen van het gebruik ervan. De stichting biedt financiële, organisatorische en juridische ondersteuning aan de bredere open-source geospatiale gemeenschap."
+      "content": "OSGeo is een non-profitorganisatie die zich richt op het ondersteunen van de ontwikkeling van open-source geospatiale software en het bevorderen van het gebruik ervan. De stichting biedt financiÃ«le, organisatorische en juridische ondersteuning aan de bredere open-source geospatiale gemeenschap."
     },
     "support": {
       "title": "Support",
@@ -78,7 +78,7 @@
     },
     "events": {
       "title": "FOSS4G Belgium Evenementen",
-      "content": "Een van de belangrijkste activiteiten van OSGeo Belgium is het organiseren van evenementen die de open-source geospatiale gemeenschap in België samenbrengen. Ons belangrijkste evenement is FOSS4G Belgium."
+      "content": "Een van de belangrijkste activiteiten van OSGeo Belgium is het organiseren van evenementen die de open-source geospatiale gemeenschap in BelgiÃ« samenbrengen. Ons belangrijkste evenement is FOSS4G Belgium."
     },
     "projects": {
       "title": "Open Source Projecten",
@@ -94,7 +94,7 @@
       "title": "Onze Kanalen",
       "mailingLabel": "Hoofddiscussie",
       "chatLabel": "Realtime chat",
-      "matrixNote": "Nieuw bij Matrix? Maak in 2 min een gratis account aan — de ruimte opent rechtstreeks in uw browser, zonder installatie."
+      "matrixNote": "Nieuw bij Matrix? Maak in 2 min een gratis account aan â€” de ruimte opent rechtstreeks in uw browser, zonder installatie."
     },
     "resources": {
       "title": "Webbronnen"
@@ -107,24 +107,24 @@
     }
   },
   "maps": {
-    "title": "Call for Maps — Kaartengalerij",
+    "title": "Call for Maps â€” Kaartengalerij",
     "content": "De Maps Competition is een vaste waarde van FOSS4G Belgium sinds 2022. Stuur uw kaart gemaakt met open source tools en zie hem tentoongesteld op de conferentie.",
     "tradition": {
       "title": "Een FOSS4G Belgium traditie",
       "content": "Sinds 2022 dienen deelnemers kaarten in gemaakt met open source software. De beste inzendingen worden geselecteerd, in groot formaat afgedrukt en de hele conferentiedag tentoongesteld."
     },
     "criteria": {
-      "title": "Inzendings­criteria",
-      "software": "Kaart volledig gemaakt met open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscape…)",
+      "title": "InzendingsÂ­criteria",
+      "software": "Kaart volledig gemaakt met open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscapeâ€¦)",
       "resolution": "Hoge-resolutiebestand: PNG of PDF, minimaal 300 dpi, formaat A2 of A1",
-      "theme": "Elk thema toegestaan: stedelijk, milieu, geschiedenis, transport, kunst, open data…",
+      "theme": "Elk thema toegestaan: stedelijk, milieu, geschiedenis, transport, kunst, open dataâ€¦",
       "legend": "Een legende en een titel zijn verplicht",
       "description": "Een korte beschrijving (max. 150 woorden) met vermelding van de gebruikte tools"
     },
-    "intentNote": "Meld uw intentie vóór 15 september zodat wij de nodige ruimte in de galerij kunnen reserveren.",
+    "intentNote": "Meld uw intentie vÃ³Ã³r 15 september zodat wij de nodige ruimte in de galerij kunnen reserveren.",
     "selection": {
       "title": "Selectie en tentoonstelling",
-      "committee": "Selectie door het organisatiecomité begin oktober",
+      "committee": "Selectie door het organisatiecomitÃ© begin oktober",
       "print": "Geselecteerde kaarten afgedrukt in groot formaat",
       "display": "Tentoonstelling de hele dag op 15 oktober",
       "credit": "Auteurs vermeld op de kaarten en in het programma"
@@ -138,7 +138,7 @@
       "closesDate": "8 oktober 2026",
       "closesLabel": "Deadline inzending",
       "selectionDate": "Half oktober 2026",
-      "selectionLabel": "Selectie door het comité",
+      "selectionLabel": "Selectie door het comitÃ©",
       "eventDate": "15 oktober 2026",
       "eventLabel": "Tentoonstelling in Tour & Taxis, Brussel"
     },
@@ -152,7 +152,7 @@
   "present": {
     "callToPresentations": {
       "title": "Oproep voor voorstellen",
-      "teaser": "Help ons om van de editie van 2026 een succes te maken! FOSS4G België vindt plaats op 15 oktober 2026.",
+      "teaser": "Help ons om van de editie van 2026 een succes te maken! FOSS4G BelgiÃ« vindt plaats op 15 oktober 2026.",
       "opensLabel": "Opening:",
       "opensDate": "7 juli 2026",
       "closesLabel": "Deadline:",
@@ -204,7 +204,7 @@
       "quality": "Kwaliteit van de ingestuurde voorstellen",
       "relevance": "Relevantie voor het publiek",
       "program": "Plaats binnen het programma",
-      "note": "De keuze van het programmacomité is finaal en bindend. De beslissingen van het programmacomité reflecteren niet de mening van de werkgevers van de leden."
+      "note": "De keuze van het programmacomitÃ© is finaal en bindend. De beslissingen van het programmacomitÃ© reflecteren niet de mening van de werkgevers van de leden."
     },
     "timeline": {
       "title": "Kalender",
@@ -221,7 +221,7 @@
     },
     "deadline": {
       "title": "Deadline",
-      "text": "De deadline voor het insturen van voorstellen is 10 augustus 2026, maar we nodigen sprekers uit om hun voorstellen zo snel mogelijk in te sturen. Voorstellen zullen geëvalueerd worden door het programmacomité en de auteurs zullen bericht krijgen of hun bijdrage aanvaard werd. Alle aanvaarde voorstellen zullen op de website geplaatst worden."
+      "text": "De deadline voor het insturen van voorstellen is 10 augustus 2026, maar we nodigen sprekers uit om hun voorstellen zo snel mogelijk in te sturen. Voorstellen zullen geÃ«valueerd worden door het programmacomitÃ© en de auteurs zullen bericht krijgen of hun bijdrage aanvaard werd. Alle aanvaarde voorstellen zullen op de website geplaatst worden."
     },
     "questions": {
       "title": "Vragen?",
@@ -229,7 +229,7 @@
     }
   },
   "volunteer": {
-    "title": "Oproep voor Vrijwilligers — FOSS4G Belgium 2026",
+    "title": "Oproep voor Vrijwilligers â€” FOSS4G Belgium 2026",
     "content": "FOSS4G Belgium draait op de energie van de gemeenschap. Sluit u aan bij het vrijwilligersteam en help 15 oktober 2026 te realiseren op Tour & Taxis, Brussel.",
     "contactUs": "Neem Contact Op",
     "perks": {
@@ -266,7 +266,7 @@
         "desc": "Opstelling en bewaking van de kaartengalerij"
       },
       "coordination": {
-        "title": "Algemene Coördinatie",
+        "title": "Algemene CoÃ¶rdinatie",
         "spots": "1 tot 2 vrijwilligers",
         "desc": "Ondersteuning van het organisatieteam en probleemoplossing"
       }
@@ -276,17 +276,17 @@
       "opensDate": "7 juli 2026",
       "opensLabel": "Online vrijwilligersinschrijvingen open",
       "meetup1Date": "4 juni 2026",
-      "meetup1Label": "Ontmoeting ter plaatse — Cercle des Voyageurs, Brussel (vanaf 18u)",
+      "meetup1Label": "Ontmoeting ter plaatse â€” Cercle des Voyageurs, Brussel (vanaf 18u)",
       "meetup2Date": "3 september 2026",
-      "meetup2Label": "Ontmoeting ter plaatse — Cercle des Voyageurs, Brussel (vanaf 18u)",
+      "meetup2Label": "Ontmoeting ter plaatse â€” Cercle des Voyageurs, Brussel (vanaf 18u)",
       "briefingDate": "10 oktober 2026",
       "briefingLabel": "Online briefing",
       "eventDate": "15 oktober 2026",
-      "eventLabel": "Vrijwilligersdag — Tour & Taxis, Brussel"
+      "eventLabel": "Vrijwilligersdag â€” Tour & Taxis, Brussel"
     },
     "apply": {
       "title": "Nu betrokken raken",
-      "content": "Geen deadline — schrijf u in op de mailinglijst of sluit u aan bij het OSGeo Belgium Matrix-kanaal om aanvragen live te volgen en uw interesse kenbaar te maken.",
+      "content": "Geen deadline â€” schrijf u in op de mailinglijst of sluit u aan bij het OSGeo Belgium Matrix-kanaal om aanvragen live te volgen en uw interesse kenbaar te maken.",
       "matrixLabel": "Matrix #osgeo-be vervoegen",
       "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
     }
@@ -343,7 +343,7 @@
       "coSponsorLunch": "(Co-)sponsor van de lunch op uw naam",
       "booth": "Presentatiestand",
       "dedicatedPost": "Gewijd bericht op sociale media",
-      "miniPresentation": "Optionele mini-presentatie (2–3 min): uw open source engagement in België",
+      "miniPresentation": "Optionele mini-presentatie (2â€“3 min): uw open source engagement in BelgiÃ«",
       "tshirtGift": "OSGeo Belgium t-shirt als geschenk",
       "stickersGift": "FOSS4G 2026 stickers als geschenk",
       "logoOnFoss4g": "Logo op foss4g.be",
@@ -352,27 +352,27 @@
       "smallBooth": "Kleine presentatiestand",
       "inProgramAtBreaks": "Vermeld in het programma bij de gesponsorde pauzes",
       "socialMention": "Vermelding sociale media",
-      "officialInvoice": "Een officiële factuur wordt u bezorgd"
+      "officialInvoice": "Een officiÃ«le factuur wordt u bezorgd"
     },
     "tiers": {
       "gold": {
         "title": "Gold",
-        "price": "€1.200",
+        "price": "â‚¬1.200",
         "cta": "Word Gold Sponsor"
       },
       "silver": {
         "title": "Silver",
-        "price": "€500",
+        "price": "â‚¬500",
         "cta": "Word Silver Sponsor"
       },
       "bronze": {
         "title": "Bronze",
-        "price": "€250",
+        "price": "â‚¬250",
         "cta": "Word Bronze Sponsor"
       },
       "community": {
         "title": "Community",
-        "price": "€100",
+        "price": "â‚¬100",
         "description": "Ideaal voor landmeters, zelfstandige consultants en bedrijven die het evenement via hun opleidingsbudget willen ondersteunen.",
         "cta": "Inschrijven als Community Sponsor"
       }
@@ -393,7 +393,7 @@
   },
   "schedule": {
     "title": "Programma",
-    "subtitle": "15 oktober 2026 • Brussel, België",
+    "subtitle": "15 oktober 2026 â€¢ Brussel, BelgiÃ«",
     "stats": {
       "presentations": "Presentaties",
       "speakers": "Sprekers",
@@ -405,9 +405,9 @@
     },
     "filters": {
       "allTracks": "Alle Tracks",
-      "track1": "Zaal 1",
-      "track2": "Zaal 2",
-      "track3": "Zaal 3",
+      "track1": "Agora",
+      "track2": "Sylva",
+      "track3": "Aqua",
       "talksOnly": "Alleen presentaties"
     },
     "upcoming": {

--- a/pages/schedule.vue
+++ b/pages/schedule.vue
@@ -587,22 +587,30 @@ function isTalkExpanded(time: string, track: string): boolean {
                       isCurrentTimeSlot(slot.time) && isEventDay ? 'border-2 border-primary' : 'border border-gray-200'
                     ]"
                   >
-                    <!-- Track Color Header -->
+                    <!-- Track Color Header — amber for workshops -->
                     <div
                       :class="[
-                        'h-1',
-                        `bg-${getTrackConfig(talk.track).color}`
+                        'h-1.5',
+                        talk.duration && talk.duration >= 90 ? 'bg-warning' : `bg-${getTrackConfig(talk.track).color}`
                       ]"
-                      :aria-label="`${getTrackConfig(talk.track).label} talk`"
+                      :aria-label="`${getTrackConfig(talk.track).label} ${talk.duration && talk.duration >= 90 ? 'workshop' : 'talk'}`"
                     ></div>
                     
                     <!-- Card Content -->
                     <div class="p-4">
                       <!-- Track & Time Info with Languages -->
                       <div class="flex items-center justify-between mb-3">
-                        <span class="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                          {{ getTrackConfig(talk.track).label }}
-                        </span>
+                        <div class="flex items-center gap-2">
+                          <span class="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            {{ getTrackConfig(talk.track).label }}
+                          </span>
+                          <span
+                            v-if="talk.duration && talk.duration >= 90"
+                            class="text-xs font-semibold px-1.5 py-0.5 rounded bg-warning/10 text-warning-dark border border-warning/30"
+                          >
+                            Workshop
+                          </span>
+                        </div>
                         <div class="flex items-center gap-2">
                           <!-- Language Flags -->
                           <div v-if="talk.languages && talk.languages.length > 0" class="flex items-center gap-1">
@@ -669,7 +677,7 @@ function isTalkExpanded(time: string, track: string): boolean {
                         <div v-if="isTalkExpanded(slot.time, talk.track)" class="mt-4 pt-4 border-t border-gray-100">
                           <div v-if="talk.abstract" class="mb-3">
                             <h4 class="text-xs font-semibold text-gray-700 uppercase tracking-wide mb-2">{{ t('schedule.expandable.abstract') }}</h4>
-                            <p class="text-sm text-gray-600 leading-relaxed">{{ talk.abstract }}</p>
+                            <p class="text-sm text-gray-600 leading-relaxed whitespace-pre-line">{{ talk.abstract }}</p>
                           </div>
                           <div class="flex items-center gap-3">
                             <div v-if="talk.duration" class="flex items-center gap-1">


### PR DESCRIPTION
## Schedule 2026

- **\ssets/schedule-data.json\** : programme complet de la journée (08:30–18:00), 17 créneaux, 3 tracks (Agora / Sylva / Aqua), ateliers 90 min, flash talks regroupés en track_1
- **\pages/schedule.vue\** : bande ambrée + badge « Workshop » pour les sessions ≥ 90 min ; classe \whitespace-pre-line\ pour les retours à la ligne dans les abstracts
- **\locales/en.json\, \r.json\, \
l.json\** : renommage Room 1/2/3 → Agora / Sylva / Aqua