### PR TITLE
sponsors: Mergin Maps passe en Silver

### DIFF
--- a/assets/sponsors-data.json
+++ b/assets/sponsors-data.json
@@ -13,15 +13,14 @@
       "link": "https://atelier-cartographique.be/",
       "logo": "/images/sponsors/ateliercartographique-logo.svg",
       "bgClass": "bg-white"
-    }
-  ],
-  "bronze": [
+    },
     {
-      "name": "Merging Maps",
+      "name": "Mergin Maps",
       "link": "https://merginmaps.com/",
       "logo": "/images/sponsors/merginmaps.png",
       "bgClass": "bg-white"
     }
   ],
+  "bronze": [],
   "community": []
 }


### PR DESCRIPTION
Mergin Maps deplace de la categorie Bronze vers Silver dans assets/sponsors-data.json. Le nom est egalement corrige.