### PR TITLE
homepage: sponsors or en avant, inscription simplifiee, Call for Sponsors masque

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "head": {
     "title": "FOSS4G Belgium 2026",
     "subtitle": "Brussels, 15 October 2026"
@@ -35,7 +35,7 @@
     },
     "getYourTickets": "Registration coming soon",
     "registration": {
-      "title": "Free entry — registration required",
+      "title": "Free entry â€” registration required",
       "free": {
         "title": "Free participation",
         "content": "The conference is entirely free. Registration is however required for logistical reasons (capacity, catering, badges).",
@@ -43,7 +43,7 @@
       },
       "attestation": {
         "title": "Training certificate",
-        "content": "Need an attendance certificate? This is possible through an organisational sponsoring mechanism (€100).",
+        "content": "Need an attendance certificate? This is possible through an organisational sponsoring mechanism (â‚¬100).",
         "contact": "Contact board@osgeo.be",
         "contactUrl": "mailto:board@osgeo.be"
       },
@@ -57,7 +57,7 @@
       "pretix": {
         "title": "Pretix waiting list",
         "content": "Receive a personal link as soon as registrations officially open.",
-        "label": "Join the waiting list",
+        "label": "Get your ticket",
         "url": "https://pretix.eu/osgeobe/foss4gbe/"
       }
     },
@@ -94,7 +94,7 @@
       "title": "Our Channels",
       "mailingLabel": "Main discussion",
       "chatLabel": "Real-time chat",
-      "matrixNote": "New to Matrix? Create a free account in 2 min — the room opens directly in your browser, no install needed."
+      "matrixNote": "New to Matrix? Create a free account in 2 min â€” the room opens directly in your browser, no install needed."
     },
     "resources": {
       "title": "Web Resources"
@@ -107,7 +107,7 @@
     }
   },
   "maps": {
-    "title": "Call for Maps — Map Gallery",
+    "title": "Call for Maps â€” Map Gallery",
     "content": "The Maps Competition has been a highlight of FOSS4G Belgium since 2022. Submit your map made with open source tools and see it displayed at the conference.",
     "tradition": {
       "title": "A FOSS4G Belgium Tradition",
@@ -115,9 +115,9 @@
     },
     "criteria": {
       "title": "Submission Criteria",
-      "software": "Map made entirely with open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscape…)",
+      "software": "Map made entirely with open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscapeâ€¦)",
       "resolution": "High-resolution file: PNG or PDF, minimum 300 dpi, A2 or A1 format",
-      "theme": "Any theme accepted: urban, environment, history, transport, art, open data…",
+      "theme": "Any theme accepted: urban, environment, history, transport, art, open dataâ€¦",
       "legend": "A legend and a title are required",
       "description": "A short description (max 150 words) stating the tools used"
     },
@@ -229,7 +229,7 @@
     }
   },
   "volunteer": {
-    "title": "Call for Volunteers — FOSS4G Belgium 2026",
+    "title": "Call for Volunteers â€” FOSS4G Belgium 2026",
     "content": "FOSS4G Belgium runs on community energy. Join the volunteer team and help make 15 October 2026 happen at Tour & Taxis, Brussels.",
     "contactUs": "Contact Us",
     "perks": {
@@ -276,17 +276,17 @@
       "opensDate": "7 July 2026",
       "opensLabel": "Online volunteer registrations open",
       "meetup1Date": "4 June 2026",
-      "meetup1Label": "In-person meetup — Cercle des Voyageurs, Brussels (from 6 pm)",
+      "meetup1Label": "In-person meetup â€” Cercle des Voyageurs, Brussels (from 6 pm)",
       "meetup2Date": "3 September 2026",
-      "meetup2Label": "In-person meetup — Cercle des Voyageurs, Brussels (from 6 pm)",
+      "meetup2Label": "In-person meetup â€” Cercle des Voyageurs, Brussels (from 6 pm)",
       "briefingDate": "10 October 2026",
       "briefingLabel": "Online briefing",
       "eventDate": "15 October 2026",
-      "eventLabel": "Volunteer day — Tour & Taxis, Brussels"
+      "eventLabel": "Volunteer day â€” Tour & Taxis, Brussels"
     },
     "apply": {
       "title": "Get involved now",
-      "content": "No deadline — join the mailing list or the OSGeo Belgium Matrix channel to follow requests in real time and express your interest.",
+      "content": "No deadline â€” join the mailing list or the OSGeo Belgium Matrix channel to follow requests in real time and express your interest.",
       "matrixLabel": "Join Matrix #osgeo-be",
       "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
     }
@@ -343,7 +343,7 @@
       "coSponsorLunch": "(Co-)sponsor of the lunch in your name",
       "booth": "Exhibition booth",
       "dedicatedPost": "Dedicated social media post",
-      "miniPresentation": "Optional mini-talk (2–3 min): your open source commitment in Belgium",
+      "miniPresentation": "Optional mini-talk (2â€“3 min): your open source commitment in Belgium",
       "tshirtGift": "OSGeo Belgium t-shirt as a gift",
       "stickersGift": "FOSS4G 2026 stickers as a gift",
       "logoOnFoss4g": "Logo on foss4g.be",
@@ -357,22 +357,22 @@
     "tiers": {
       "gold": {
         "title": "Gold",
-        "price": "€1,200",
+        "price": "â‚¬1,200",
         "cta": "Become a Gold Sponsor"
       },
       "silver": {
         "title": "Silver",
-        "price": "€500",
+        "price": "â‚¬500",
         "cta": "Become a Silver Sponsor"
       },
       "bronze": {
         "title": "Bronze",
-        "price": "€250",
+        "price": "â‚¬250",
         "cta": "Become a Bronze Sponsor"
       },
       "community": {
         "title": "Community",
-        "price": "€100",
+        "price": "â‚¬100",
         "description": "Ideal for surveyors, independent consultants and companies wishing to support the event via their training budget.",
         "cta": "Register as a Community Sponsor"
       }
@@ -393,7 +393,7 @@
   },
   "schedule": {
     "title": "Program",
-    "subtitle": "15 October 2026 • Brussels, Belgium",
+    "subtitle": "15 October 2026 â€¢ Brussels, Belgium",
     "stats": {
       "presentations": "Presentations",
       "speakers": "Speakers",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "head": {
     "title": "FOSS4G Belgique 2026",
     "subtitle": "Bruxelles, 15 octobre 2026"
@@ -57,7 +57,7 @@
       "pretix": {
         "title": "Liste d'attente Pretix",
         "content": "Recevez un lien personnel dès l'ouverture officielle.",
-        "label": "Rejoindre la liste d'attente",
+        "label": "Obtenir mon billet",
         "url": "https://pretix.eu/osgeobe/foss4gbe/"
       }
     },

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "head": {
     "title": "FOSS4G Belgïe 2026",
     "subtitle": "Brussel, 15 oktober 2026"
@@ -57,7 +57,7 @@
       "pretix": {
         "title": "Pretix wachtlijst",
         "content": "Ontvang een persoonlijke link zodra de inschrijvingen officieel openen.",
-        "label": "Deelnemen aan de wachtlijst",
+        "label": "Registreer je",
         "url": "https://pretix.eu/osgeobe/foss4gbe/"
       }
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -72,56 +72,12 @@ onUnmounted(() => clearInterval(timer))
             </div>
         </section>
 
-        <!-- Inscriptions -->
-        <section id="get-your-tickets" class="bg-off-white px-6 py-6 rounded-xl shadow max-w-3xl mx-auto flex flex-col items-center">
-            <h2 class="text-xl font-bold text-center">{{ $t('index.registration.title') }}</h2>
-
-
-            <h3 class="text-lg font-bold mb-2 mx-8">🎟️ {{ $t('index.registration.free.title') }}</h3>
-            <p class="text-xs text-neutral-dark mb-2">{{ $t('index.registration.free.content') }}</p>
-            <p class="text-xs text-main-color-4 font-medium mt-2">{{ $t('index.registration.free.opensNote') }}</p>
-            <p class="text-xs text-neutral-dark italic mb-2 mt-4">{{ $t('index.registration.legalNote') }}</p>
-
-        </section>
-            <!-- Note légale -->
-
-            <!-- CTAs -->
-        <section id="registration-ctas" class="max-w-3xl mx-auto flex flex-col items-center justify-center space-y-4">
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div class="bg-off-white rounded-xl shadow px-5 py-5">
-                    <p class="font-semibold text-sm mb-1">📧 {{ $t('index.registration.mailing.title') }}</p>
-                    <p class="text-xs text-neutral-dark mb-3">{{ $t('index.registration.mailing.content') }}</p>
-                    <a
-                        :href="$t('index.registration.mailing.url')"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="inline-block text-xs border-2 border-main-color-4 text-main-color-4 font-semibold px-4 py-1.5 rounded-lg hover:bg-main-color-4 hover:text-white transition"
-                    >
-                        {{ $t('index.registration.mailing.label') }}
-                    </a>
-                </div>
-                <div class="bg-off-white rounded-xl shadow px-5 py-5">
-                    <p class="font-semibold text-sm mb-1">🎟️ {{ $t('index.registration.pretix.title') }}</p>
-                    <p class="text-xs text-neutral-dark mb-3">{{ $t('index.registration.pretix.content') }}</p>
-                    <a
-                        :href="$t('index.registration.pretix.url')"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="inline-block text-xs border-2 border-main-color-2 text-main-color-2 font-semibold px-4 py-1.5 rounded-lg hover:bg-main-color-2 hover:text-white transition"
-                    >
-                        {{ $t('index.registration.pretix.label') }}
-                    </a>
-                </div>
-            </div>
-        </section>
-
         <!-- Our gold sponsors -->
         <section
             id="gold-sponsors"
             class="bg-off-white py-6 rounded-xl shadow max-w-3xl mx-auto flex flex-col items-center justify-center space-y-4"
         >
-
-           <h2 class="text-lg font-bold mb-2 mx-8">
+            <h2 class="text-lg font-bold mb-2 mx-8">
                 {{ $t('index.goldSponsors.thanksTo') }}
                 <NuxtLinkLocale to="/our-sponsors" class="underline text-main-color-2">
                     {{ $t('index.goldSponsors.goldSponsors') }}
@@ -149,7 +105,6 @@ onUnmounted(() => clearInterval(timer))
                 </a>
             </div>
 
-
             <div class="w-full">
                 <p class="text-right mx-4 text-main-color-2">
                     <NuxtLinkLocale to="/our-sponsors" class="underline">
@@ -159,37 +114,19 @@ onUnmounted(() => clearInterval(timer))
             </div>
         </section>
 
-        <!-- ABOUT -->
-        <section
-            id="about"
-            class="bg-off-white px-6 py-6 rounded-xl shadow max-w-3xl mx-auto flex flex-col items-center"
-        >
-            <h2 class="text-lg font-bold mb-3">{{ $t('index.about.title') }}</h2>
-            <p class="text-sm text-neutral-dark text-center mb-4">
-                {{ $t('index.about.teaser') }}
-            </p>
-
-            <ul class="w-full grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-                <li class="flex flex-col items-center space-y-2">
-                    <MdiIcon icon="mdiBullhorn" size="2.5em" class="text-main-color-2" />
-                    <span class="text-sm font-medium text-main-color-2">{{ $t('index.about.features.keynotes') }}</span>
-                </li>
-                <li class="flex flex-col items-center space-y-2">
-                    <MdiIcon icon="mdiAccountMultiple" size="2.5em" class="text-main-color-3" />
-                    <span class="text-sm font-medium text-main-color-3">{{ $t('index.about.features.networking') }}</span>
-                </li>
-                <li class="flex flex-col items-center space-y-2">
-                    <MdiIcon icon="mdiTools" size="2.5em" class="text-main-color-4" />
-                    <span class="text-sm font-medium text-main-color-4">{{ $t('index.about.features.osgeoTools') }}</span>
-                </li>
-            </ul>
-
-            <NuxtLinkLocale
-                to="/about"
-                class="flex justify-center border-2 border-primary text-primary font-semibold px-4 py-2 rounded-lg hover:bg-primary hover:text-white transition text-sm"
+        <!-- Inscriptions -->
+        <section id="get-your-tickets" class="bg-off-white px-6 py-6 rounded-xl shadow max-w-3xl mx-auto flex flex-col items-center text-center space-y-4">
+            <h2 class="text-xl font-bold">{{ $t('index.registration.title') }}</h2>
+            <p class="text-sm text-neutral-dark">{{ $t('index.registration.free.content') }}</p>
+            <a
+                :href="$t('index.registration.pretix.url')"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-block bg-main-color-2 text-white font-semibold px-6 py-3 rounded-lg hover:opacity-90 transition text-sm"
             >
-                {{ $t('index.about.learnMore') }}
-            </NuxtLinkLocale>
+                🎟️ {{ $t('index.registration.pretix.label') }}
+            </a>
+            <p class="text-xs text-neutral-dark italic">{{ $t('index.registration.legalNote') }}</p>
         </section>
 
         <!-- CARDS GRID -->
@@ -233,8 +170,8 @@ onUnmounted(() => clearInterval(timer))
                 </NuxtLinkLocale>
             </div !-->
 
-            <!-- Call for Sponsors -->
-            <div class="bg-off-white px-2 rounded-xl shadow overflow-hidden flex flex-col sm:flex-row">
+            <!-- Call for Sponsors — hidden, sponsoring closed -->
+            <!-- div class="bg-off-white px-2 rounded-xl shadow overflow-hidden flex flex-col sm:flex-row">
                 <div class="p-5 flex flex-col justify-center flex-1">
                     <h2 class="text-lg font-bold mb-2">{{ $t('cards.callForSponsors.title') }}</h2>
                     <p class="text-sm text-neutral-dark mb-4">{{ $t('cards.callForSponsors.description') }}</p>
@@ -252,7 +189,7 @@ onUnmounted(() => clearInterval(timer))
                         class="w-full h-full object-contain p-4"
                     />
                 </div>
-            </div>
+            </div -->
 
             <!-- Volunteers -->
             <div class="bg-off-white px-2 rounded-xl shadow overflow-hidden flex flex-col sm:flex-row">
@@ -301,6 +238,39 @@ onUnmounted(() => clearInterval(timer))
                     <MdiIcon icon="mdiMap" size="5em" class="text-main-color-1 opacity-60" />
                 </div>
             </div>
+        </section>
+
+        <!-- ABOUT -->
+        <section
+            id="about"
+            class="bg-off-white px-6 py-6 rounded-xl shadow max-w-3xl mx-auto flex flex-col items-center"
+        >
+            <h2 class="text-lg font-bold mb-3">{{ $t('index.about.title') }}</h2>
+            <p class="text-sm text-neutral-dark text-center mb-4">
+                {{ $t('index.about.teaser') }}
+            </p>
+
+            <ul class="w-full grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+                <li class="flex flex-col items-center space-y-2">
+                    <MdiIcon icon="mdiBullhorn" size="2.5em" class="text-main-color-2" />
+                    <span class="text-sm font-medium text-main-color-2">{{ $t('index.about.features.keynotes') }}</span>
+                </li>
+                <li class="flex flex-col items-center space-y-2">
+                    <MdiIcon icon="mdiAccountMultiple" size="2.5em" class="text-main-color-3" />
+                    <span class="text-sm font-medium text-main-color-3">{{ $t('index.about.features.networking') }}</span>
+                </li>
+                <li class="flex flex-col items-center space-y-2">
+                    <MdiIcon icon="mdiTools" size="2.5em" class="text-main-color-4" />
+                    <span class="text-sm font-medium text-main-color-4">{{ $t('index.about.features.osgeoTools') }}</span>
+                </li>
+            </ul>
+
+            <NuxtLinkLocale
+                to="/about"
+                class="flex justify-center border-2 border-primary text-primary font-semibold px-4 py-2 rounded-lg hover:bg-primary hover:text-white transition text-sm"
+            >
+                {{ $t('index.about.learnMore') }}
+            </NuxtLinkLocale>
         </section>
 
         <!-- Countdown -->


### PR DESCRIPTION
Mise a jour de la page d'accueil :
- Bloc sponsors or deplace juste sous le hero
- Section inscription simplifiee : un seul bouton Pretix (Get your ticket)
- Carte Call for Sponsors commentee (sponsoring ferme)
- Section About deplacee apres la grille de cartes
- Locales EN/FR/NL : label bouton Pretix mis a jour