### PR TITLE
maps: guide de soumission par email, sections reordonees, badge retire

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -144,9 +144,17 @@
     },
     "submit": {
       "title": "How to submit?",
-      "content": "The submission form will be available here from 7 July 2026. Sign up to the mailing list to be notified when it opens.",
-      "mailingLabel": "Subscribe to the mailing list",
-      "mailingUrl": "https://lists.osgeo.org/cgi-bin/mailman/listinfo/belgium"
+      "content": "Send an e-mail to map@foss4g.be with the following information:",
+      "item1": "Title of the map",
+      "item2": "Author's name",
+      "item3": "Organization / affiliation",
+      "item4": "Additional map authors, if any",
+      "item5": "Brief description of the map — please mention the software and data used",
+      "item6": "URL to the digital map or more information, if applicable",
+      "item7": "Whether we should print it, or whether you will bring it to the conference yourself",
+      "item8": "Send it via e-mail to map@foss4g.be",
+      "emailLabel": "map@foss4g.be",
+      "emailUrl": "mailto:map@foss4g.be"
     }
   },
   "present": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -144,9 +144,17 @@
     },
     "submit": {
       "title": "Comment soumettre ?",
-      "content": "Le formulaire de soumission sera disponible ici dès le 7 juillet 2026. Inscrivez-vous à la mailing list pour être notifié(e) à l'ouverture.",
-      "mailingLabel": "S'inscrire à la mailing list",
-      "mailingUrl": "https://lists.osgeo.org/cgi-bin/mailman/listinfo/belgium"
+      "content": "Envoyez un e-mail à map@foss4g.be avec les informations suivantes :",
+      "item1": "Titre de la carte",
+      "item2": "Nom de l'auteur·e",
+      "item3": "Organisation / affiliation",
+      "item4": "Co-auteur·e·s éventuel·le·s",
+      "item5": "Brève description de la carte — mentionnez le logiciel et les données utilisés",
+      "item6": "URL vers la carte numérique ou informations complémentaires, si disponible",
+      "item7": "Si nous devons l'imprimer ou si vous l'apportez vous-même à la conférence",
+      "item8": "Envoyez le tout par e-mail à map@foss4g.be",
+      "emailLabel": "map@foss4g.be",
+      "emailUrl": "mailto:map@foss4g.be"
     }
   },
   "present": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -144,9 +144,17 @@
     },
     "submit": {
       "title": "Hoe indienen?",
-      "content": "Het inzendingsformulier is beschikbaar vanaf 27 juni 2026. Schrijf u in op de mailinglijst om een melding te ontvangen.",
-      "mailingLabel": "Inschrijven op de mailinglijst",
-      "mailingUrl": "https://lists.osgeo.org/cgi-bin/mailman/listinfo/belgium"
+      "content": "Stuur een e-mail naar map@foss4g.be met de volgende informatie:",
+      "item1": "Titel van de kaart",
+      "item2": "Naam van de auteur",
+      "item3": "Organisatie / affiliatie",
+      "item4": "Eventuele co-auteurs",
+      "item5": "Korte beschrijving van de kaart — vermeld de gebruikte software en gegevens",
+      "item6": "URL naar de digitale kaart of meer informatie, indien beschikbaar",
+      "item7": "Of wij het moeten afdrukken of dat u het zelf meebrengt naar de conferentie",
+      "item8": "Stuur alles per e-mail naar map@foss4g.be",
+      "emailLabel": "map@foss4g.be",
+      "emailUrl": "mailto:map@foss4g.be"
     }
   },
   "present": {

--- a/pages/maps.vue
+++ b/pages/maps.vue
@@ -8,9 +8,6 @@
                     <h1 class="text-xl font-bold mb-2">{{ $t('maps.title') }}</h1>
                     <p class="text-sm text-neutral-dark mb-3">{{ $t('maps.content') }}</p>
                     <div class="flex flex-wrap gap-3 text-xs">
-                        <span class="bg-main-color-4/10 text-main-color-4 font-semibold px-3 py-1 rounded-full">
-                            {{ $t('maps.timeline.opensLabel') }} {{ $t('maps.timeline.opensDate') }}
-                        </span>
                         <span class="bg-orange-100 text-orange-600 font-semibold px-3 py-1 rounded-full">
                             {{ $t('maps.timeline.intentLabel') }} {{ $t('maps.timeline.intentDate') }}
                         </span>
@@ -26,6 +23,25 @@
             <div class="bg-off-white px-6 py-6 rounded-xl shadow sm:col-span-2">
                 <h2 class="text-lg font-bold mb-2">{{ $t('maps.tradition.title') }}</h2>
                 <p class="text-sm text-neutral-dark">{{ $t('maps.tradition.content') }}</p>
+            </div>
+
+            <!-- How to submit -->
+            <div class="bg-off-white px-6 py-6 rounded-xl shadow sm:col-span-2">
+                <h2 class="text-lg font-bold mb-2">{{ $t('maps.submit.title') }}</h2>
+                <p class="text-sm text-neutral-dark mb-4">{{ $t('maps.submit.content') }}</p>
+                <ol class="space-y-2 mb-6 list-none">
+                    <li v-for="n in 7" :key="n" class="flex items-start gap-3 text-sm text-neutral-dark">
+                        <span class="shrink-0 w-6 h-6 rounded-full bg-main-color-4/10 text-main-color-4 font-bold flex items-center justify-center text-xs">{{ n }}</span>
+                        <span>{{ $t(`maps.submit.item${n}`) }}</span>
+                    </li>
+                </ol>
+                <a
+                    :href="$t('maps.submit.emailUrl')"
+                    class="inline-flex items-center gap-2 bg-main-color-4 text-white font-semibold px-5 py-2.5 rounded-lg hover:opacity-90 transition text-sm"
+                >
+                    <MdiIcon icon="mdiEmailOutline" size="1.1em" />
+                    {{ $t('maps.submit.emailLabel') }}
+                </a>
             </div>
 
             <!-- Criteria -->
@@ -69,21 +85,6 @@
                         </li>
                     </ol>
                 </div>
-            </div>
-
-            <!-- How to submit -->
-            <div class="bg-off-white px-6 py-6 rounded-xl shadow sm:col-span-2">
-                <h2 class="text-lg font-bold mb-2">{{ $t('maps.submit.title') }}</h2>
-                <p class="text-sm text-neutral-dark mb-4">{{ $t('maps.submit.content') }}</p>
-                <a
-                    :href="$t('maps.submit.mailingUrl')"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center gap-2 border-2 border-main-color-4 text-main-color-4 font-semibold px-4 py-2 rounded-lg hover:bg-main-color-4 hover:text-white transition text-sm"
-                >
-                    <MdiIcon icon="mdiEmailOutline" size="1.1em" />
-                    {{ $t('maps.submit.mailingLabel') }}
-                </a>
             </div>
 
         </section>


### PR DESCRIPTION
Mise a jour de la page Maps :
- Suppression du badge 'Submissions open 7 July 2026' dans le hero
- Ajout d'une section 'How to submit' avec 7 elements numerotes + bouton email (map@foss4g.be)
- Ordre des sections : Hero -> Tradition -> How to submit -> Criteria -> Intent -> Selection
- Locales EN/FR/NL : cles maps.submit mises a jour (items 1-7 + emailLabel/emailUrl)