### PR TITLE
fix maps: @ in locale strings causes vue-i18n 500 on /maps pages

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -144,17 +144,14 @@
     },
     "submit": {
       "title": "How to submit?",
-      "content": "Send an e-mail to map@foss4g.be with the following information:",
+      "content": "Send an e-mail to the address below with the following information:",
       "item1": "Title of the map",
       "item2": "Author's name",
       "item3": "Organization / affiliation",
       "item4": "Additional map authors, if any",
       "item5": "Brief description of the map — please mention the software and data used",
       "item6": "URL to the digital map or more information, if applicable",
-      "item7": "Whether we should print it, or whether you will bring it to the conference yourself",
-      "item8": "Send it via e-mail to map@foss4g.be",
-      "emailLabel": "map@foss4g.be",
-      "emailUrl": "mailto:map@foss4g.be"
+      "item7": "Whether we should print it, or whether you will bring it to the conference yourself"
     }
   },
   "present": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -144,17 +144,14 @@
     },
     "submit": {
       "title": "Comment soumettre ?",
-      "content": "Envoyez un e-mail à map@foss4g.be avec les informations suivantes :",
+      "content": "Envoyez un e-mail à l'adresse ci-dessous avec les informations suivantes :",
       "item1": "Titre de la carte",
       "item2": "Nom de l'auteur·e",
       "item3": "Organisation / affiliation",
       "item4": "Co-auteur·e·s éventuel·le·s",
       "item5": "Brève description de la carte — mentionnez le logiciel et les données utilisés",
       "item6": "URL vers la carte numérique ou informations complémentaires, si disponible",
-      "item7": "Si nous devons l'imprimer ou si vous l'apportez vous-même à la conférence",
-      "item8": "Envoyez le tout par e-mail à map@foss4g.be",
-      "emailLabel": "map@foss4g.be",
-      "emailUrl": "mailto:map@foss4g.be"
+      "item7": "Si nous devons l'imprimer ou si vous l'apportez vous-même à la conférence"
     }
   },
   "present": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -144,17 +144,14 @@
     },
     "submit": {
       "title": "Hoe indienen?",
-      "content": "Stuur een e-mail naar map@foss4g.be met de volgende informatie:",
+      "content": "Stuur een e-mail naar het onderstaande adres met de volgende informatie:",
       "item1": "Titel van de kaart",
       "item2": "Naam van de auteur",
       "item3": "Organisatie / affiliatie",
       "item4": "Eventuele co-auteurs",
       "item5": "Korte beschrijving van de kaart — vermeld de gebruikte software en gegevens",
       "item6": "URL naar de digitale kaart of meer informatie, indien beschikbaar",
-      "item7": "Of wij het moeten afdrukken of dat u het zelf meebrengt naar de conferentie",
-      "item8": "Stuur alles per e-mail naar map@foss4g.be",
-      "emailLabel": "map@foss4g.be",
-      "emailUrl": "mailto:map@foss4g.be"
+      "item7": "Of wij het moeten afdrukken of dat u het zelf meebrengt naar de conferentie"
     }
   },
   "present": {

--- a/pages/maps.vue
+++ b/pages/maps.vue
@@ -36,11 +36,11 @@
                     </li>
                 </ol>
                 <a
-                    :href="$t('maps.submit.emailUrl')"
+                    href="mailto:map@foss4g.be"
                     class="inline-flex items-center gap-2 bg-main-color-4 text-white font-semibold px-5 py-2.5 rounded-lg hover:opacity-90 transition text-sm"
                 >
                     <MdiIcon icon="mdiEmailOutline" size="1.1em" />
-                    {{ $t('maps.submit.emailLabel') }}
+                    map@foss4g.be
                 </a>
             </div>
 


### PR DESCRIPTION
vue-i18n interprete le caractere @ dans les valeurs de messages comme une reference de message lie (linked message), causant une erreur 500 sur toutes les pages /maps lors du build statique.

Correction :
- locales EN/FR/NL : suppression de map@foss4g.be des cles maps.submit.content, item8, emailLabel, emailUrl
- pages/maps.vue : email mailto:map@foss4g.be integre directement dans le template

A merger en priorite pour restaurer le build.