### PR TITLE
fix locales: restaurer encodage UTF-8 correct EN/FR/NL

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "head": {
     "title": "FOSS4G Belgium 2026",
     "subtitle": "Brussels, 15 October 2026"
@@ -35,7 +35,7 @@
     },
     "getYourTickets": "Registration coming soon",
     "registration": {
-      "title": "Free entry â€” registration required",
+      "title": "Free entry — registration required",
       "free": {
         "title": "Free participation",
         "content": "The conference is entirely free. Registration is however required for logistical reasons (capacity, catering, badges).",
@@ -43,7 +43,7 @@
       },
       "attestation": {
         "title": "Training certificate",
-        "content": "Need an attendance certificate? This is possible through an organisational sponsoring mechanism (â‚¬100).",
+        "content": "Need an attendance certificate? This is possible through an organisational sponsoring mechanism (€100).",
         "contact": "Contact board@osgeo.be",
         "contactUrl": "mailto:board@osgeo.be"
       },
@@ -94,7 +94,7 @@
       "title": "Our Channels",
       "mailingLabel": "Main discussion",
       "chatLabel": "Real-time chat",
-      "matrixNote": "New to Matrix? Create a free account in 2 min â€” the room opens directly in your browser, no install needed."
+      "matrixNote": "New to Matrix? Create a free account in 2 min — the room opens directly in your browser, no install needed."
     },
     "resources": {
       "title": "Web Resources"
@@ -107,7 +107,7 @@
     }
   },
   "maps": {
-    "title": "Call for Maps â€” Map Gallery",
+    "title": "Call for Maps — Map Gallery",
     "content": "The Maps Competition has been a highlight of FOSS4G Belgium since 2022. Submit your map made with open source tools and see it displayed at the conference.",
     "tradition": {
       "title": "A FOSS4G Belgium Tradition",
@@ -115,9 +115,9 @@
     },
     "criteria": {
       "title": "Submission Criteria",
-      "software": "Map made entirely with open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscapeâ€¦)",
+      "software": "Map made entirely with open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscape…)",
       "resolution": "High-resolution file: PNG or PDF, minimum 300 dpi, A2 or A1 format",
-      "theme": "Any theme accepted: urban, environment, history, transport, art, open dataâ€¦",
+      "theme": "Any theme accepted: urban, environment, history, transport, art, open data…",
       "legend": "A legend and a title are required",
       "description": "A short description (max 150 words) stating the tools used"
     },
@@ -234,7 +234,7 @@
     }
   },
   "volunteer": {
-    "title": "Call for Volunteers â€” FOSS4G Belgium 2026",
+    "title": "Call for Volunteers — FOSS4G Belgium 2026",
     "content": "FOSS4G Belgium runs on community energy. Join the volunteer team and help make 15 October 2026 happen at Tour & Taxis, Brussels.",
     "contactUs": "Contact Us",
     "perks": {
@@ -281,17 +281,17 @@
       "opensDate": "7 July 2026",
       "opensLabel": "Online volunteer registrations open",
       "meetup1Date": "4 June 2026",
-      "meetup1Label": "In-person meetup â€” Cercle des Voyageurs, Brussels (from 6 pm)",
+      "meetup1Label": "In-person meetup — Cercle des Voyageurs, Brussels (from 6 pm)",
       "meetup2Date": "3 September 2026",
-      "meetup2Label": "In-person meetup â€” Cercle des Voyageurs, Brussels (from 6 pm)",
+      "meetup2Label": "In-person meetup — Cercle des Voyageurs, Brussels (from 6 pm)",
       "briefingDate": "10 October 2026",
       "briefingLabel": "Online briefing",
       "eventDate": "15 October 2026",
-      "eventLabel": "Volunteer day â€” Tour & Taxis, Brussels"
+      "eventLabel": "Volunteer day — Tour & Taxis, Brussels"
     },
     "apply": {
       "title": "Get involved now",
-      "content": "No deadline â€” join the mailing list or the OSGeo Belgium Matrix channel to follow requests in real time and express your interest.",
+      "content": "No deadline — join the mailing list or the OSGeo Belgium Matrix channel to follow requests in real time and express your interest.",
       "matrixLabel": "Join Matrix #osgeo-be",
       "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
     }
@@ -348,7 +348,7 @@
       "coSponsorLunch": "(Co-)sponsor of the lunch in your name",
       "booth": "Exhibition booth",
       "dedicatedPost": "Dedicated social media post",
-      "miniPresentation": "Optional mini-talk (2â€“3 min): your open source commitment in Belgium",
+      "miniPresentation": "Optional mini-talk (2–3 min): your open source commitment in Belgium",
       "tshirtGift": "OSGeo Belgium t-shirt as a gift",
       "stickersGift": "FOSS4G 2026 stickers as a gift",
       "logoOnFoss4g": "Logo on foss4g.be",
@@ -362,22 +362,22 @@
     "tiers": {
       "gold": {
         "title": "Gold",
-        "price": "â‚¬1,200",
+        "price": "€1,200",
         "cta": "Become a Gold Sponsor"
       },
       "silver": {
         "title": "Silver",
-        "price": "â‚¬500",
+        "price": "€500",
         "cta": "Become a Silver Sponsor"
       },
       "bronze": {
         "title": "Bronze",
-        "price": "â‚¬250",
+        "price": "€250",
         "cta": "Become a Bronze Sponsor"
       },
       "community": {
         "title": "Community",
-        "price": "â‚¬100",
+        "price": "€100",
         "description": "Ideal for surveyors, independent consultants and companies wishing to support the event via their training budget.",
         "cta": "Register as a Community Sponsor"
       }
@@ -398,7 +398,7 @@
   },
   "schedule": {
     "title": "Program",
-    "subtitle": "15 October 2026 â€¢ Brussels, Belgium",
+    "subtitle": "15 October 2026 • Brussels, Belgium",
     "stats": {
       "presentations": "Presentations",
       "speakers": "Speakers",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,13 +1,13 @@
-﻿{
+{
   "head": {
     "title": "FOSS4G Belgique 2026",
     "subtitle": "Bruxelles, 15 octobre 2026"
   },
   "nav": {
     "home": "Accueil",
-    "about": "Ã€ propos",
-    "callForPresentations": "Appel Ã  prÃ©sentations",
-    "callForMaps": "PrÃ©sentez votre carte",
+    "about": "À propos",
+    "callForPresentations": "Appel à présentations",
+    "callForMaps": "Présentez votre carte",
     "schedule": "Programme",
     "ourSponsors": "Nos sponsors",
     "becomeSponsor": "Devenir sponsor",
@@ -18,40 +18,40 @@
   },
   "index": {
     "about": {
-      "title": "Ã€ propos de FOSS4G",
-      "teaser": "Rejoignez-nous le 15 octobre 2026 Ã  Bruxelles pour une confÃ©rence d'une journÃ©e avec discours, ateliers pratiques et rÃ©seautage autour des outils gÃ©ospatiaux open-source.",
+      "title": "À propos de FOSS4G",
+      "teaser": "Rejoignez-nous le 15 octobre 2026 à Bruxelles pour une conférence d'une journée avec discours, ateliers pratiques et réseautage autour des outils géospatiaux open-source.",
       "features": {
-        "keynotes": "Discours & PrÃ©sentations",
-        "networking": "RÃ©seautage Communautaire",
+        "keynotes": "Discours & Présentations",
+        "networking": "Réseautage Communautaire",
         "osgeoTools": "Outils OSGEO"
       },
       "learnMore": "En savoir plus"
     },
     "goldSponsors": {
-      "thanksTo": "Merci Ã  nos",
+      "thanksTo": "Merci à nos",
       "goldSponsors": "sponsors or",
-      "whoSupportUs": "qui supportent notre Ã©vÃ©nement.",
-      "showAllSponsors": "DÃ©couvrez tous nos sponsors"
+      "whoSupportUs": "qui supportent notre événement.",
+      "showAllSponsors": "Découvrez tous nos sponsors"
     },
-    "getYourTickets": "Inscriptions bientÃ´t disponibles",
+    "getYourTickets": "Inscriptions bientôt disponibles",
     "registration": {
-      "title": "EntrÃ©e libre â€” inscription obligatoire",
+      "title": "Entrée libre — inscription obligatoire",
       "free": {
         "title": "Participation gratuite",
-        "content": "La confÃ©rence est entiÃ¨rement gratuite. Une inscription prÃ©alable est cependant requise pour des raisons logistiques (capacitÃ©, catering, badges).",
-        "opensNote": "Inscriptions ouvertes en septembre 2026, une fois le programme publiÃ©."
+        "content": "La conférence est entièrement gratuite. Une inscription préalable est cependant requise pour des raisons logistiques (capacité, catering, badges).",
+        "opensNote": "Inscriptions ouvertes en septembre 2026, une fois le programme publié."
       },
       "attestation": {
         "title": "Attestation de formation",
-        "content": "Besoin d'une attestation pour votre participation ? C'est possible via un mÃ©canisme de sponsoring organisationnel (100 â‚¬).",
+        "content": "Besoin d'une attestation pour votre participation ? C'est possible via un mécanisme de sponsoring organisationnel (100 €).",
         "contact": "Contacter board@osgeo.be",
         "contactUrl": "mailto:board@osgeo.be"
       },
-      "legalNote": "ConformÃ©ment aux conditions du lieu, aucun droit d'entrÃ©e n'est perÃ§u. Tout soutien financier passe exclusivement par le sponsoring organisationnel.",
+      "legalNote": "Conformément aux conditions du lieu, aucun droit d'entrée n'est perçu. Tout soutien financier passe exclusivement par le sponsoring organisationnel.",
       "mailing": {
         "title": "Mailing list",
-        "content": "Soyez notifiÃ©(e) par email dÃ¨s l'ouverture des inscriptions.",
-        "label": "S'inscrire Ã  la mailing list",
+        "content": "Soyez notifié(e) par email dès l'ouverture des inscriptions.",
+        "label": "S'inscrire à la mailing list",
         "url": "https://lists.osgeo.org/cgi-bin/mailman/listinfo/belgium"
       },
       "pretix": {
@@ -70,63 +70,63 @@
     },
     "mission": {
       "title": "Notre mission",
-      "content": "La foundation OSGeo est une organisation Ã  but non lucratif dont la mission est de soutenir le dÃ©veloppement de logiciels gÃ©ospatiaux open source et de promouvoir leur utilisation. La fondation fournit un soutien financier, organisationnel et juridique Ã  la communautÃ© gÃ©ospatiale open source au sens large."
+      "content": "La foundation OSGeo est une organisation à but non lucratif dont la mission est de soutenir le développement de logiciels géospatiaux open source et de promouvoir leur utilisation. La fondation fournit un soutien financier, organisationnel et juridique à la communauté géospatiale open source au sens large."
     },
     "support": {
       "title": "Support",
-      "content": "Notre organisation sert d'entitÃ© juridique indÃ©pendante oÃ¹ les membres peuvent contribuer par du code, des financements et d'autres ressources, assurant la prÃ©servation des contributions pour le bÃ©nÃ©fice public. OSGeo agit aussi en tant qu'organisation de sensibilisation et de plaidoyer, offrant forum et infrastructure partagÃ©e pour renforcer la collaboration entre projets."
+      "content": "Notre organisation sert d'entité juridique indépendante où les membres peuvent contribuer par du code, des financements et d'autres ressources, assurant la préservation des contributions pour le bénéfice public. OSGeo agit aussi en tant qu'organisation de sensibilisation et de plaidoyer, offrant forum et infrastructure partagée pour renforcer la collaboration entre projets."
     },
     "events": {
-      "title": "Ã‰vÃ©nements FOSS4G Belgium",
-      "content": "Une des activitÃ©s principales de l'OSGeo Belgium est l'organisation d'Ã©vÃ©nements rassemblant la communautÃ© gÃ©ospatiale open source en Belgique. Notre Ã©vÃ©nement le plus important est le FOSS4G Belgium."
+      "title": "Événements FOSS4G Belgium",
+      "content": "Une des activités principales de l'OSGeo Belgium est l'organisation d'événements rassemblant la communauté géospatiale open source en Belgique. Notre événement le plus important est le FOSS4G Belgium."
     },
     "projects": {
       "title": "Projets Open Source",
-      "content": "Les projets soutenus par la fondation OSGeo sont tous librement disponibles et utilisables sous une licence open source certifiÃ©e par l'OSI. Ces projets incluent des logiciels gÃ©ospatiaux populaires tels que QGIS, GeoServer, PostGIS, et bien d'autres qui sont largement utilisÃ©s dans l'industrie."
+      "content": "Les projets soutenus par la fondation OSGeo sont tous librement disponibles et utilisables sous une licence open source certifiée par l'OSI. Ces projets incluent des logiciels géospatiaux populaires tels que QGIS, GeoServer, PostGIS, et bien d'autres qui sont largement utilisés dans l'industrie."
     }
   },
   "contact": {
     "contactUs": "Contactez-nous",
-    "askByEmailTo": "Pour toute demande, vous pouvez nous envoyer un courriel Ã ",
+    "askByEmailTo": "Pour toute demande, vous pouvez nous envoyer un courriel à",
     "sendAnEmail": "Envoyer un email",
-    "followUs": "RÃ©seaux sociaux",
+    "followUs": "Réseaux sociaux",
     "channels": {
       "title": "Nos canaux",
       "mailingLabel": "Discussion principale",
-      "chatLabel": "Chat en temps rÃ©el",
-      "matrixNote": "Nouveau sur Matrix ? CrÃ©ez un compte gratuit en 2 min â€” le salon s'ouvre directement dans le navigateur, sans installation."
+      "chatLabel": "Chat en temps réel",
+      "matrixNote": "Nouveau sur Matrix ? Créez un compte gratuit en 2 min — le salon s'ouvre directement dans le navigateur, sans installation."
     },
     "resources": {
       "title": "Ressources web"
     },
     "member": {
       "title": "Devenez membre",
-      "content": "Rejoignez OSGeo Belgium en vous inscrivant sur notre mailing list. L'adhÃ©sion est ouverte Ã  tous, gratuitement.",
-      "cta": "S'inscrire Ã  la mailing list",
-      "note": "La mailing list est notre canal de communication principal. Vous recevrez des informations sur nos Ã©vÃ©nements et pourrez participer aux discussions."
+      "content": "Rejoignez OSGeo Belgium en vous inscrivant sur notre mailing list. L'adhésion est ouverte à tous, gratuitement.",
+      "cta": "S'inscrire à la mailing list",
+      "note": "La mailing list est notre canal de communication principal. Vous recevrez des informations sur nos événements et pourrez participer aux discussions."
     }
   },
   "maps": {
-    "title": "Call for Maps â€” Galerie cartographique",
-    "content": "La Maps Competition est un rendez-vous incontournable de FOSS4G Belgium depuis 2022. Soumettez votre carte rÃ©alisÃ©e avec des logiciels libres et voyez-la exposÃ©e lors de la confÃ©rence.",
+    "title": "Call for Maps — Galerie cartographique",
+    "content": "La Maps Competition est un rendez-vous incontournable de FOSS4G Belgium depuis 2022. Soumettez votre carte réalisée avec des logiciels libres et voyez-la exposée lors de la conférence.",
     "tradition": {
       "title": "Une tradition FOSS4G Belgium",
-      "content": "Depuis 2022, les participants soumettent des cartes rÃ©alisÃ©es avec des logiciels libres. Les meilleures sont sÃ©lectionnÃ©es, imprimÃ©es en grand format et exposÃ©es tout au long de la journÃ©e de confÃ©rence."
+      "content": "Depuis 2022, les participants soumettent des cartes réalisées avec des logiciels libres. Les meilleures sont sélectionnées, imprimées en grand format et exposées tout au long de la journée de conférence."
     },
     "criteria": {
-      "title": "CritÃ¨res de soumission",
-      "software": "Carte rÃ©alisÃ©e entiÃ¨rement avec des logiciels libres (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscapeâ€¦)",
-      "resolution": "Fichier haute rÃ©solution : PNG ou PDF, minimum 300 dpi, format A2 ou A1",
-      "theme": "Tout thÃ¨me acceptÃ© : urbain, environnement, histoire, transport, art, donnÃ©es ouvertesâ€¦",
-      "legend": "Une lÃ©gende et un titre sont requis",
-      "description": "Une courte description (150 mots max) indiquant les outils utilisÃ©s"
+      "title": "Critères de soumission",
+      "software": "Carte réalisée entièrement avec des logiciels libres (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscape…)",
+      "resolution": "Fichier haute résolution : PNG ou PDF, minimum 300 dpi, format A2 ou A1",
+      "theme": "Tout thème accepté : urbain, environnement, histoire, transport, art, données ouvertes…",
+      "legend": "Une légende et un titre sont requis",
+      "description": "Une courte description (150 mots max) indiquant les outils utilisés"
     },
-    "intentNote": "Marquez votre intention avant le 15 septembre afin que nous puissions rÃ©server l'espace nÃ©cessaire dans la galerie.",
+    "intentNote": "Marquez votre intention avant le 15 septembre afin que nous puissions réserver l'espace nécessaire dans la galerie.",
     "selection": {
-      "title": "SÃ©lection et exposition",
-      "committee": "SÃ©lection par le comitÃ© d'organisation dÃ©but octobre",
-      "print": "Cartes sÃ©lectionnÃ©es imprimÃ©es en grand format",
-      "display": "Exposition tout au long de la journÃ©e du 15 octobre",
+      "title": "Sélection et exposition",
+      "committee": "Sélection par le comité d'organisation début octobre",
+      "print": "Cartes sélectionnées imprimées en grand format",
+      "display": "Exposition tout au long de la journée du 15 octobre",
       "credit": "Mention des auteurs sur les cartes et dans le programme"
     },
     "timeline": {
@@ -134,13 +134,13 @@
       "opensDate": "7 juillet 2026",
       "opensLabel": "Ouverture des soumissions",
       "intentDate": "15 septembre 2026",
-      "intentLabel": "Date limite d'intention (rÃ©servation de l'espace)",
+      "intentLabel": "Date limite d'intention (réservation de l'espace)",
       "closesDate": "8 octobre 2026",
       "closesLabel": "Date limite de soumission",
       "selectionDate": "Mi-octobre 2026",
-      "selectionLabel": "SÃ©lection par le comitÃ©",
+      "selectionLabel": "Sélection par le comité",
       "eventDate": "15 octobre 2026",
-      "eventLabel": "Exposition Ã  Tour & Taxis, Bruxelles"
+      "eventLabel": "Exposition à Tour & Taxis, Bruxelles"
     },
     "submit": {
       "title": "Comment soumettre ?",
@@ -156,33 +156,33 @@
   },
   "present": {
     "callToPresentations": {
-      "title": "Appel Ã  propositions",
-      "teaser": "Contribuez au succÃ¨s de l'Ã©dition 2026. FOSS4G Belgique aura lieu le 15 octobre 2026.",
+      "title": "Appel à propositions",
+      "teaser": "Contribuez au succès de l'édition 2026. FOSS4G Belgique aura lieu le 15 octobre 2026.",
       "opensLabel": "Ouverture :",
       "opensDate": "7 juillet 2026",
       "closesLabel": "Date limite :",
-      "closesDate": "25 aoÃ»t 2026"
+      "closesDate": "25 août 2026"
     },
     "formats": {
       "title": "Formats",
       "flash": {
         "title": "Flash talk",
         "duration": "2 minutes",
-        "desc": "PrÃ©senter briÃ¨vement un sujet de votre choix, une carte ou un poster"
+        "desc": "Présenter brièvement un sujet de votre choix, une carte ou un poster"
       },
       "presentation": {
-        "title": "PrÃ©sentation",
+        "title": "Présentation",
         "duration": "25 min (20 min + 5 min Q/R)",
-        "desc": "PrÃ©senter un sujet de maniÃ¨re approfondie"
+        "desc": "Présenter un sujet de manière approfondie"
       },
       "workshop": {
         "title": "Workshop",
-        "duration": "90 minutes (aprÃ¨s-midi)",
-        "desc": "Session pratique initiant les participants Ã  un logiciel, un plug-in, â€¦"
+        "duration": "90 minutes (après-midi)",
+        "desc": "Session pratique initiant les participants à un logiciel, un plug-in, …"
       }
     },
     "topics": {
-      "title": "ThÃ©matiques",
+      "title": "Thématiques",
       "osm": "OpenStreetMap - cartographie collaborative + Open Data",
       "postgresql": "PostgreSQL - PostGIS",
       "qgis": "QGIS + GRASS GIS",
@@ -190,43 +190,43 @@
       "other": "Autres sujets"
     },
     "submission": {
-      "title": "ModalitÃ©s de soumission",
+      "title": "Modalités de soumission",
       "intro": "Votre proposition doit inclure :",
       "fieldTitle": "Titre",
-      "fieldSummary": "RÃ©sumÃ© (max 250 mots)",
-      "fieldWorkshop": "Si workshop : prÃ©ciser les prÃ©requis techniques pour les participants",
-      "fieldMaps": "Si carte ou poster : indiquer s'il doit Ãªtre imprimÃ© ou apportÃ© par vous-mÃªme",
+      "fieldSummary": "Résumé (max 250 mots)",
+      "fieldWorkshop": "Si workshop : préciser les prérequis techniques pour les participants",
+      "fieldMaps": "Si carte ou poster : indiquer s'il doit être imprimé ou apporté par vous-même",
       "fieldLanguage": "Langue(s)",
       "fieldLevel": "Niveau",
-      "fieldFormat": "Format(s) souhaitÃ©(s) (plusieurs choix possibles)",
+      "fieldFormat": "Format(s) souhaité(s) (plusieurs choix possibles)",
       "formTitle": "Soumission des propositions",
-      "formIntro": "Les propositions doivent Ãªtre dÃ©posÃ©es via le formulaire :",
+      "formIntro": "Les propositions doivent être déposées via le formulaire :",
       "formLink": "Call for proposals | Framaforms.org",
       "formUrl": "https://framaforms.org/call-for-proposals-1780600203"
     },
     "criterias": {
-      "title": "CritÃ¨res d'Ã©valuation",
-      "quality": "QualitÃ© des soumissions",
+      "title": "Critères d'évaluation",
+      "quality": "Qualité des soumissions",
       "relevance": "Pertinence pour le public",
-      "program": "CohÃ©rence avec le programme",
-      "note": "Le choix du comitÃ© de programme est dÃ©finitif et sans appel. Les dÃ©cisions du comitÃ© de programme ne reflÃ¨tent l'opinion d'aucun employeur des membres."
+      "program": "Cohérence avec le programme",
+      "note": "Le choix du comité de programme est définitif et sans appel. Les décisions du comité de programme ne reflètent l'opinion d'aucun employeur des membres."
     },
     "timeline": {
       "title": "Calendrier",
       "opensDate": "7 juillet 2026",
       "opensLabel": "Ouverture des soumissions",
-      "closesDate": "25 aoÃ»t 2026",
+      "closesDate": "25 août 2026",
       "closesLabel": "Date limite de soumission",
       "notificationDate": "8 septembre 2026",
-      "notificationLabel": "Notification aux auteurÂ·eÂ·s",
+      "notificationLabel": "Notification aux auteur·e·s",
       "programDate": "15 septembre 2026",
-      "programLabel": "Programme publiÃ©",
+      "programLabel": "Programme publié",
       "eventDate": "15 octobre 2026",
-      "eventLabel": "Ã‰vÃ©nement Ã  Bruxelles"
+      "eventLabel": "Événement à Bruxelles"
     },
     "deadline": {
       "title": "Date limite",
-      "text": "La date limite de soumission est fixÃ©e au 25 aoÃ»t 2026, mais nous invitons Ã  soumettre la proposition dÃ¨s que possible. Les propositions seront Ã©valuÃ©es par le ComitÃ© du programme et les auteurs seront informÃ©s si leur contribution a Ã©tÃ© acceptÃ©e. Toutes les propositions acceptÃ©es seront publiÃ©es sur le site de l'Ã©vÃ©nement."
+      "text": "La date limite de soumission est fixée au 25 août 2026, mais nous invitons à soumettre la proposition dès que possible. Les propositions seront évaluées par le Comité du programme et les auteurs seront informés si leur contribution a été acceptée. Toutes les propositions acceptées seront publiées sur le site de l'événement."
     },
     "questions": {
       "title": "Des questions ?",
@@ -234,96 +234,96 @@
     }
   },
   "volunteer": {
-    "title": "Appel aux bÃ©nÃ©voles â€” FOSS4G Belgium 2026",
-    "content": "FOSS4G Belgium repose sur l'Ã©nergie de sa communautÃ©. Rejoignez l'Ã©quipe de bÃ©nÃ©voles pour contribuer Ã  l'organisation de la journÃ©e du 15 octobre 2026 Ã  Bruxelles.",
+    "title": "Appel aux bénévoles — FOSS4G Belgium 2026",
+    "content": "FOSS4G Belgium repose sur l'énergie de sa communauté. Rejoignez l'équipe de bénévoles pour contribuer à l'organisation de la journée du 15 octobre 2026 à Bruxelles.",
     "contactUs": "Nous contacter",
     "perks": {
       "title": "Ce que vous gagnez",
-      "tshirt": "T-shirt bÃ©nÃ©vole exclusif",
+      "tshirt": "T-shirt bénévole exclusif",
       "networking": "Rencontres avec les speakers et les participants",
-      "community": "Contribution directe Ã  la communautÃ© open source belge"
+      "community": "Contribution directe à la communauté open source belge"
     },
     "roles": {
       "title": "Postes disponibles",
       "reception": {
         "title": "Accueil & Badges",
-        "spots": "3 bÃ©nÃ©voles",
-        "desc": "Accueil des participants Ã  l'entrÃ©e et distribution du matÃ©riel"
+        "spots": "3 bénévoles",
+        "desc": "Accueil des participants à l'entrée et distribution du matériel"
       },
       "room": {
         "title": "Support en salle",
-        "spots": "4 Ã  6 bÃ©nÃ©voles",
+        "spots": "4 à 6 bénévoles",
         "desc": "Micro pendant les Q&A et signaux timing pour les orateurs"
       },
       "av": {
-        "title": "Technique audio/vidÃ©o",
-        "spots": "2 bÃ©nÃ©voles",
-        "desc": "Son, projection et gestion du streaming Ã©ventuel"
+        "title": "Technique audio/vidéo",
+        "spots": "2 bénévoles",
+        "desc": "Son, projection et gestion du streaming éventuel"
       },
       "social": {
-        "title": "RÃ©seaux sociaux",
-        "spots": "1 Ã  2 bÃ©nÃ©voles",
-        "desc": "Couverture de l'Ã©vÃ©nement en temps rÃ©el sur les plateformes sociales"
+        "title": "Réseaux sociaux",
+        "spots": "1 à 2 bénévoles",
+        "desc": "Couverture de l'événement en temps réel sur les plateformes sociales"
       },
       "maps": {
         "title": "Galerie de cartes & Expo",
-        "spots": "2 bÃ©nÃ©voles",
+        "spots": "2 bénévoles",
         "desc": "Installation et surveillance de la galerie de cartes"
       },
       "coordination": {
-        "title": "Coordination gÃ©nÃ©rale",
-        "spots": "1 Ã  2 bÃ©nÃ©voles",
-        "desc": "Support Ã  l'Ã©quipe organisatrice et rÃ©solution des imprÃ©vus"
+        "title": "Coordination générale",
+        "spots": "1 à 2 bénévoles",
+        "desc": "Support à l'équipe organisatrice et résolution des imprévus"
       }
     },
     "timeline": {
       "title": "Calendrier",
       "opensDate": "7 juillet 2026",
-      "opensLabel": "Ouverture des inscriptions bÃ©nÃ©voles en ligne",
+      "opensLabel": "Ouverture des inscriptions bénévoles en ligne",
       "meetup1Date": "4 juin 2026",
-      "meetup1Label": "Rencontre en prÃ©sentiel â€” Cercle des Voyageurs, Bruxelles (dÃ¨s 18h)",
+      "meetup1Label": "Rencontre en présentiel — Cercle des Voyageurs, Bruxelles (dès 18h)",
       "meetup2Date": "3 septembre 2026",
-      "meetup2Label": "Rencontre en prÃ©sentiel â€” Cercle des Voyageurs, Bruxelles (dÃ¨s 18h)",
+      "meetup2Label": "Rencontre en présentiel — Cercle des Voyageurs, Bruxelles (dès 18h)",
       "briefingDate": "10 octobre 2026",
       "briefingLabel": "Briefing en ligne",
       "eventDate": "15 octobre 2026",
-      "eventLabel": "JournÃ©e bÃ©nÃ©vole â€” Tour & Taxis, Bruxelles"
+      "eventLabel": "Journée bénévole — Tour & Taxis, Bruxelles"
     },
     "apply": {
       "title": "Comment s'impliquer maintenant",
-      "content": "Pas de date limite : inscrivez-vous Ã  la mailing list ou rejoignez le salon Matrix OSGeo Belgium pour suivre les demandes en direct et manifester votre intÃ©rÃªt.",
+      "content": "Pas de date limite : inscrivez-vous à la mailing list ou rejoignez le salon Matrix OSGeo Belgium pour suivre les demandes en direct et manifester votre intérêt.",
       "matrixLabel": "Rejoindre Matrix #osgeo-be",
       "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
     }
   },
   "cards": {
     "callForTopics": {
-      "title": "Appel Ã  prÃ©sentations",
-      "description": "Nous recherchons des prÃ©sentations sur des sujets sur la thÃ©matique gÃ©ospatial open-source. (Date limite: Ã  prÃ©ciser)",
-      "button": "PrÃ©senter"
+      "title": "Appel à présentations",
+      "description": "Nous recherchons des présentations sur des sujets sur la thématique géospatial open-source. (Date limite: à préciser)",
+      "button": "Présenter"
     },
     "schedulePreview": {
-      "comingSoon": "BientÃ´t disponible",
-      "title": "AperÃ§u du programme",
+      "comingSoon": "Bientôt disponible",
+      "title": "Aperçu du programme",
       "day1Label": "Jour 1 :",
-      "day1Items": "Accueil, Keynote, DÃ©jeuner",
+      "day1Items": "Accueil, Keynote, Déjeuner",
       "day2Label": "Jour 2 :",
-      "day2Items": "Ateliers, PrÃ©sentations",
+      "day2Items": "Ateliers, Présentations",
       "button": "Voir le programme complet"
     },
     "callForSponsors": {
       "title": "Devenez sponsor",
-      "description": "Soutenez FOSS4G Belgium 2026 et gagnez en visibilitÃ© au sein de la communautÃ© gÃ©ospatiale open-source.",
+      "description": "Soutenez FOSS4G Belgium 2026 et gagnez en visibilité au sein de la communauté géospatiale open-source.",
       "button": "Devenir sponsor"
     },
     "volunteers": {
       "title": "Aidez-nous!",
-      "description": "Mettez vos compÃ©tences et votre Ã©nergie au service du succÃ¨s de FOSS4G Belgium 2026.",
+      "description": "Mettez vos compétences et votre énergie au service du succès de FOSS4G Belgium 2026.",
       "button": "Participer"
     },
     "callForMaps": {
       "title": "Galerie de cartes",
-      "description": "Vous crÃ©ez des cartes avec des outils open source ou des donnÃ©es ouvertes ? Soumettez votre travail Ã  la Map Gallery.",
+      "description": "Vous créez des cartes avec des outils open source ou des données ouvertes ? Soumettez votre travail à la Map Gallery.",
       "button": "Soumettre une carte"
     }
   },
@@ -340,97 +340,97 @@
     "community": "Participants Community",
     "hero": {
       "title": "Soutenez FOSS4G Belgium 2026",
-      "description": "En sponsorisant FOSS4G Belgium, vous soutenez la communautÃ© gÃ©ospatiale open source belge et gagnez en visibilitÃ© auprÃ¨s de ses membres."
+      "description": "En sponsorisant FOSS4G Belgium, vous soutenez la communauté géospatiale open source belge et gagnez en visibilité auprès de ses membres."
     },
     "features": {
-      "logoOnFoss4gBig": "Logo (grand format) sur foss4g.be + banniÃ¨re dans l'en-tÃªte du site",
-      "logoInProgramHeader": "Logo dans l'en-tÃªte du programme imprimÃ© (A3/A0)",
-      "coSponsorLunch": "(Co-)sponsor du lunch Ã  votre nom",
-      "booth": "Stand de prÃ©sentation",
-      "dedicatedPost": "Post dÃ©diÃ© sur les rÃ©seaux sociaux",
-      "miniPresentation": "Mini-prÃ©sentation optionnelle (2â€“3 min) : votre engagement open source en Belgique",
+      "logoOnFoss4gBig": "Logo (grand format) sur foss4g.be + bannière dans l'en-tête du site",
+      "logoInProgramHeader": "Logo dans l'en-tête du programme imprimé (A3/A0)",
+      "coSponsorLunch": "(Co-)sponsor du lunch à votre nom",
+      "booth": "Stand de présentation",
+      "dedicatedPost": "Post dédié sur les réseaux sociaux",
+      "miniPresentation": "Mini-présentation optionnelle (2–3 min) : votre engagement open source en Belgique",
       "tshirtGift": "T-shirt OSGeo Belgium offert",
       "stickersGift": "Stickers FOSS4G 2026 offerts",
       "logoOnFoss4g": "Logo sur foss4g.be",
       "logoOnSponsorsPage": "Logo sur la page des sponsors",
-      "namedMomentSilver": "Co-sponsoring possible d'une pause cafÃ© ou du verre de clÃ´ture (au choix)",
-      "smallBooth": "Petit stand de prÃ©sentation",
-      "inProgramAtBreaks": "Repris dans le programme au niveau des pauses sponsorisÃ©es",
-      "socialMention": "Mention rÃ©seaux sociaux",
+      "namedMomentSilver": "Co-sponsoring possible d'une pause café ou du verre de clôture (au choix)",
+      "smallBooth": "Petit stand de présentation",
+      "inProgramAtBreaks": "Repris dans le programme au niveau des pauses sponsorisées",
+      "socialMention": "Mention réseaux sociaux",
       "officialInvoice": "Une facture officielle vous sera transmise"
     },
     "tiers": {
       "gold": {
         "title": "Gold",
-        "price": "1 200 â‚¬",
+        "price": "1 200 €",
         "cta": "Devenir sponsor Gold"
       },
       "silver": {
         "title": "Silver",
-        "price": "500 â‚¬",
+        "price": "500 €",
         "cta": "Devenir sponsor Silver"
       },
       "bronze": {
         "title": "Bronze",
-        "price": "250 â‚¬",
+        "price": "250 €",
         "cta": "Devenir sponsor Bronze"
       },
       "community": {
         "title": "Community",
-        "price": "100 â‚¬",
-        "description": "IdÃ©al pour gÃ©omÃ¨tres, consultants indÃ©pendants et entreprises souhaitant soutenir l'Ã©vÃ©nement via leur budget formation.",
+        "price": "100 €",
+        "description": "Idéal pour géomètres, consultants indépendants et entreprises souhaitant soutenir l'événement via leur budget formation.",
         "cta": "S'inscrire comme Community sponsor"
       }
     },
     "coc": {
       "title": "Code de conduite des sponsors",
-      "text": "Les sponsors de FOSS4G Belgium partagent les valeurs d'OSGeo : ouverture, collaboration et respect de la communautÃ©. En devenant sponsor, vous vous engagez Ã  respecter le <a href=\"https://www.osgeo.org/resources/osgeo-code-of-conduct/\" target=\"_blank\" rel=\"noopener\">Code de conduite OSGeo</a>. Les modalitÃ©s dÃ©taillÃ©es seront prÃ©cisÃ©es dans le dossier de sponsoring."
+      "text": "Les sponsors de FOSS4G Belgium partagent les valeurs d'OSGeo : ouverture, collaboration et respect de la communauté. En devenant sponsor, vous vous engagez à respecter le <a href=\"https://www.osgeo.org/resources/osgeo-code-of-conduct/\" target=\"_blank\" rel=\"noopener\">Code de conduite OSGeo</a>. Les modalités détaillées seront précisées dans le dossier de sponsoring."
     },
     "support": {
       "title": "Soutenez FOSS4G Belgium 2026",
-      "description": "Construisons ensemble la carte de la communautÃ© gÃ©ospatiale open source belge. Votre soutien rend l'Ã©vÃ©nement possible et vous positionne au cÅ“ur de cet Ã©cosystÃ¨me.",
+      "description": "Construisons ensemble la carte de la communauté géospatiale open source belge. Votre soutien rend l'événement possible et vous positionne au cœur de cet écosystème.",
       "cta": "Devenir Sponsor"
     },
     "footer": {
-      "thankYou": "Merci Ã  nos sponsors",
+      "thankYou": "Merci à nos sponsors",
       "subtext": "Votre soutien rend FOSS4G Belgium 2026 possible !"
     }
   },
   "schedule": {
     "title": "Programme",
-    "subtitle": "15 octobre 2026 â€¢ Bruxelles, Belgique",
+    "subtitle": "15 octobre 2026 • Bruxelles, Belgique",
     "stats": {
-      "presentations": "PrÃ©sentations",
+      "presentations": "Présentations",
       "speakers": "Orateurs",
       "tracks": "Pistes",
-      "duration": "DurÃ©e"
+      "duration": "Durée"
     },
     "search": {
-      "placeholder": "Rechercher des prÃ©sentations, orateurs ou organisations..."
+      "placeholder": "Rechercher des présentations, orateurs ou organisations..."
     },
     "filters": {
       "allTracks": "Toutes les Pistes",
       "track1": "Agora",
       "track2": "Sylva",
       "track3": "Aqua",
-      "talksOnly": "PrÃ©sentations seulement"
+      "talksOnly": "Présentations seulement"
     },
     "upcoming": {
-      "upNext": "Ã€ venir Ã "
+      "upNext": "À venir à"
     },
     "expandable": {
-      "abstract": "RÃ©sumÃ©",
+      "abstract": "Résumé",
       "minutes": "minutes",
       "moreText": "plus"
     },
     "languages": {
       "english": "Anglais",
-      "french": "FranÃ§ais",
-      "dutch": "NÃ©erlandais"
+      "french": "Français",
+      "dutch": "Néerlandais"
     },
     "empty": {
-      "title": "Programme bientÃ´t disponible",
-      "description": "Le programme de FOSS4G Belgium 2026 sera annoncÃ© prochainement."
+      "title": "Programme bientôt disponible",
+      "description": "Le programme de FOSS4G Belgium 2026 sera annoncé prochainement."
     }
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "head": {
-    "title": "FOSS4G BelgÃ¯e 2026",
+    "title": "FOSS4G Belgïe 2026",
     "subtitle": "Brussel, 15 oktober 2026"
   },
   "nav": {
@@ -35,7 +35,7 @@
     },
     "getYourTickets": "Inschrijvingen binnenkort beschikbaar",
     "registration": {
-      "title": "Vrije toegang â€” inschrijving verplicht",
+      "title": "Vrije toegang — inschrijving verplicht",
       "free": {
         "title": "Gratis deelname",
         "content": "De conferentie is volledig gratis. Een voorafgaande inschrijving is echter vereist om logistieke redenen (capaciteit, catering, badges).",
@@ -43,11 +43,11 @@
       },
       "attestation": {
         "title": "Opleidingsattest",
-        "content": "Heeft u een aanwezigheidsattest nodig? Dat kan via een organisatorisch sponsormechanisme (â‚¬100).",
+        "content": "Heeft u een aanwezigheidsattest nodig? Dat kan via een organisatorisch sponsormechanisme (€100).",
         "contact": "Contact board@osgeo.be",
         "contactUrl": "mailto:board@osgeo.be"
       },
-      "legalNote": "Conform de voorwaarden van de locatie wordt geen toegangsprijs aangerekend. Alle financiÃ«le steun verloopt uitsluitend via organisatorische sponsoring.",
+      "legalNote": "Conform de voorwaarden van de locatie wordt geen toegangsprijs aangerekend. Alle financiële steun verloopt uitsluitend via organisatorische sponsoring.",
       "mailing": {
         "title": "Mailinglijst",
         "content": "Word per e-mail verwittigd zodra de inschrijvingen openen.",
@@ -70,7 +70,7 @@
     },
     "mission": {
       "title": "Onze Missie",
-      "content": "OSGeo is een non-profitorganisatie die zich richt op het ondersteunen van de ontwikkeling van open-source geospatiale software en het bevorderen van het gebruik ervan. De stichting biedt financiÃ«le, organisatorische en juridische ondersteuning aan de bredere open-source geospatiale gemeenschap."
+      "content": "OSGeo is een non-profitorganisatie die zich richt op het ondersteunen van de ontwikkeling van open-source geospatiale software en het bevorderen van het gebruik ervan. De stichting biedt financiële, organisatorische en juridische ondersteuning aan de bredere open-source geospatiale gemeenschap."
     },
     "support": {
       "title": "Support",
@@ -78,7 +78,7 @@
     },
     "events": {
       "title": "FOSS4G Belgium Evenementen",
-      "content": "Een van de belangrijkste activiteiten van OSGeo Belgium is het organiseren van evenementen die de open-source geospatiale gemeenschap in BelgiÃ« samenbrengen. Ons belangrijkste evenement is FOSS4G Belgium."
+      "content": "Een van de belangrijkste activiteiten van OSGeo Belgium is het organiseren van evenementen die de open-source geospatiale gemeenschap in België samenbrengen. Ons belangrijkste evenement is FOSS4G Belgium."
     },
     "projects": {
       "title": "Open Source Projecten",
@@ -94,7 +94,7 @@
       "title": "Onze Kanalen",
       "mailingLabel": "Hoofddiscussie",
       "chatLabel": "Realtime chat",
-      "matrixNote": "Nieuw bij Matrix? Maak in 2 min een gratis account aan â€” de ruimte opent rechtstreeks in uw browser, zonder installatie."
+      "matrixNote": "Nieuw bij Matrix? Maak in 2 min een gratis account aan — de ruimte opent rechtstreeks in uw browser, zonder installatie."
     },
     "resources": {
       "title": "Webbronnen"
@@ -107,24 +107,24 @@
     }
   },
   "maps": {
-    "title": "Call for Maps â€” Kaartengalerij",
+    "title": "Call for Maps — Kaartengalerij",
     "content": "De Maps Competition is een vaste waarde van FOSS4G Belgium sinds 2022. Stuur uw kaart gemaakt met open source tools en zie hem tentoongesteld op de conferentie.",
     "tradition": {
       "title": "Een FOSS4G Belgium traditie",
       "content": "Sinds 2022 dienen deelnemers kaarten in gemaakt met open source software. De beste inzendingen worden geselecteerd, in groot formaat afgedrukt en de hele conferentiedag tentoongesteld."
     },
     "criteria": {
-      "title": "InzendingsÂ­criteria",
-      "software": "Kaart volledig gemaakt met open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscapeâ€¦)",
+      "title": "Inzendings­criteria",
+      "software": "Kaart volledig gemaakt met open source software (QGIS, GRASS, R, Python/Matplotlib, D3.js, MapLibre, Inkscape…)",
       "resolution": "Hoge-resolutiebestand: PNG of PDF, minimaal 300 dpi, formaat A2 of A1",
-      "theme": "Elk thema toegestaan: stedelijk, milieu, geschiedenis, transport, kunst, open dataâ€¦",
+      "theme": "Elk thema toegestaan: stedelijk, milieu, geschiedenis, transport, kunst, open data…",
       "legend": "Een legende en een titel zijn verplicht",
       "description": "Een korte beschrijving (max. 150 woorden) met vermelding van de gebruikte tools"
     },
-    "intentNote": "Meld uw intentie vÃ³Ã³r 15 september zodat wij de nodige ruimte in de galerij kunnen reserveren.",
+    "intentNote": "Meld uw intentie vóór 15 september zodat wij de nodige ruimte in de galerij kunnen reserveren.",
     "selection": {
       "title": "Selectie en tentoonstelling",
-      "committee": "Selectie door het organisatiecomitÃ© begin oktober",
+      "committee": "Selectie door het organisatiecomité begin oktober",
       "print": "Geselecteerde kaarten afgedrukt in groot formaat",
       "display": "Tentoonstelling de hele dag op 15 oktober",
       "credit": "Auteurs vermeld op de kaarten en in het programma"
@@ -138,7 +138,7 @@
       "closesDate": "8 oktober 2026",
       "closesLabel": "Deadline inzending",
       "selectionDate": "Half oktober 2026",
-      "selectionLabel": "Selectie door het comitÃ©",
+      "selectionLabel": "Selectie door het comité",
       "eventDate": "15 oktober 2026",
       "eventLabel": "Tentoonstelling in Tour & Taxis, Brussel"
     },
@@ -157,7 +157,7 @@
   "present": {
     "callToPresentations": {
       "title": "Oproep voor voorstellen",
-      "teaser": "Help ons om van de editie van 2026 een succes te maken! FOSS4G BelgiÃ« vindt plaats op 15 oktober 2026.",
+      "teaser": "Help ons om van de editie van 2026 een succes te maken! FOSS4G België vindt plaats op 15 oktober 2026.",
       "opensLabel": "Opening:",
       "opensDate": "7 juli 2026",
       "closesLabel": "Deadline:",
@@ -209,7 +209,7 @@
       "quality": "Kwaliteit van de ingestuurde voorstellen",
       "relevance": "Relevantie voor het publiek",
       "program": "Plaats binnen het programma",
-      "note": "De keuze van het programmacomitÃ© is finaal en bindend. De beslissingen van het programmacomitÃ© reflecteren niet de mening van de werkgevers van de leden."
+      "note": "De keuze van het programmacomité is finaal en bindend. De beslissingen van het programmacomité reflecteren niet de mening van de werkgevers van de leden."
     },
     "timeline": {
       "title": "Kalender",
@@ -226,7 +226,7 @@
     },
     "deadline": {
       "title": "Deadline",
-      "text": "De deadline voor het insturen van voorstellen is 10 augustus 2026, maar we nodigen sprekers uit om hun voorstellen zo snel mogelijk in te sturen. Voorstellen zullen geÃ«valueerd worden door het programmacomitÃ© en de auteurs zullen bericht krijgen of hun bijdrage aanvaard werd. Alle aanvaarde voorstellen zullen op de website geplaatst worden."
+      "text": "De deadline voor het insturen van voorstellen is 10 augustus 2026, maar we nodigen sprekers uit om hun voorstellen zo snel mogelijk in te sturen. Voorstellen zullen geëvalueerd worden door het programmacomité en de auteurs zullen bericht krijgen of hun bijdrage aanvaard werd. Alle aanvaarde voorstellen zullen op de website geplaatst worden."
     },
     "questions": {
       "title": "Vragen?",
@@ -234,7 +234,7 @@
     }
   },
   "volunteer": {
-    "title": "Oproep voor Vrijwilligers â€” FOSS4G Belgium 2026",
+    "title": "Oproep voor Vrijwilligers — FOSS4G Belgium 2026",
     "content": "FOSS4G Belgium draait op de energie van de gemeenschap. Sluit u aan bij het vrijwilligersteam en help 15 oktober 2026 te realiseren op Tour & Taxis, Brussel.",
     "contactUs": "Neem Contact Op",
     "perks": {
@@ -271,7 +271,7 @@
         "desc": "Opstelling en bewaking van de kaartengalerij"
       },
       "coordination": {
-        "title": "Algemene CoÃ¶rdinatie",
+        "title": "Algemene Coördinatie",
         "spots": "1 tot 2 vrijwilligers",
         "desc": "Ondersteuning van het organisatieteam en probleemoplossing"
       }
@@ -281,17 +281,17 @@
       "opensDate": "7 juli 2026",
       "opensLabel": "Online vrijwilligersinschrijvingen open",
       "meetup1Date": "4 juni 2026",
-      "meetup1Label": "Ontmoeting ter plaatse â€” Cercle des Voyageurs, Brussel (vanaf 18u)",
+      "meetup1Label": "Ontmoeting ter plaatse — Cercle des Voyageurs, Brussel (vanaf 18u)",
       "meetup2Date": "3 september 2026",
-      "meetup2Label": "Ontmoeting ter plaatse â€” Cercle des Voyageurs, Brussel (vanaf 18u)",
+      "meetup2Label": "Ontmoeting ter plaatse — Cercle des Voyageurs, Brussel (vanaf 18u)",
       "briefingDate": "10 oktober 2026",
       "briefingLabel": "Online briefing",
       "eventDate": "15 oktober 2026",
-      "eventLabel": "Vrijwilligersdag â€” Tour & Taxis, Brussel"
+      "eventLabel": "Vrijwilligersdag — Tour & Taxis, Brussel"
     },
     "apply": {
       "title": "Nu betrokken raken",
-      "content": "Geen deadline â€” schrijf u in op de mailinglijst of sluit u aan bij het OSGeo Belgium Matrix-kanaal om aanvragen live te volgen en uw interesse kenbaar te maken.",
+      "content": "Geen deadline — schrijf u in op de mailinglijst of sluit u aan bij het OSGeo Belgium Matrix-kanaal om aanvragen live te volgen en uw interesse kenbaar te maken.",
       "matrixLabel": "Matrix #osgeo-be vervoegen",
       "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
     }
@@ -348,7 +348,7 @@
       "coSponsorLunch": "(Co-)sponsor van de lunch op uw naam",
       "booth": "Presentatiestand",
       "dedicatedPost": "Gewijd bericht op sociale media",
-      "miniPresentation": "Optionele mini-presentatie (2â€“3 min): uw open source engagement in BelgiÃ«",
+      "miniPresentation": "Optionele mini-presentatie (2–3 min): uw open source engagement in België",
       "tshirtGift": "OSGeo Belgium t-shirt als geschenk",
       "stickersGift": "FOSS4G 2026 stickers als geschenk",
       "logoOnFoss4g": "Logo op foss4g.be",
@@ -357,27 +357,27 @@
       "smallBooth": "Kleine presentatiestand",
       "inProgramAtBreaks": "Vermeld in het programma bij de gesponsorde pauzes",
       "socialMention": "Vermelding sociale media",
-      "officialInvoice": "Een officiÃ«le factuur wordt u bezorgd"
+      "officialInvoice": "Een officiële factuur wordt u bezorgd"
     },
     "tiers": {
       "gold": {
         "title": "Gold",
-        "price": "â‚¬1.200",
+        "price": "€1.200",
         "cta": "Word Gold Sponsor"
       },
       "silver": {
         "title": "Silver",
-        "price": "â‚¬500",
+        "price": "€500",
         "cta": "Word Silver Sponsor"
       },
       "bronze": {
         "title": "Bronze",
-        "price": "â‚¬250",
+        "price": "€250",
         "cta": "Word Bronze Sponsor"
       },
       "community": {
         "title": "Community",
-        "price": "â‚¬100",
+        "price": "€100",
         "description": "Ideaal voor landmeters, zelfstandige consultants en bedrijven die het evenement via hun opleidingsbudget willen ondersteunen.",
         "cta": "Inschrijven als Community Sponsor"
       }
@@ -398,7 +398,7 @@
   },
   "schedule": {
     "title": "Programma",
-    "subtitle": "15 oktober 2026 â€¢ Brussel, BelgiÃ«",
+    "subtitle": "15 oktober 2026 • Brussel, België",
     "stats": {
       "presentations": "Presentaties",
       "speakers": "Sprekers",


### PR DESCRIPTION
Locales FR/NL/EN corrompues par lectures PowerShell sans encodage explicite. Symptomes : Ã au lieu de accents, tirets longs garbles. Fix : reconstruction depuis version git propre + System.IO.File UTF-8 sans BOM.