### PR TITLE
navbar: fix mobile lang + retire CfP / volunteer: inscription email ou Pretix

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -84,8 +84,7 @@
             >
                 <NuxtLinkLocale @click="close" to="/">{{ $t('nav.home') }}</NuxtLinkLocale>
                 <NuxtLinkLocale @click="close" to="/about">{{ $t('nav.about') }}</NuxtLinkLocale>
-                <NuxtLinkLocale @click="close" to="/present">{{ $t('nav.callForPresentations') }}</NuxtLinkLocale>
-                <NuxtLinkLocale @click="close" to="/maps">{{ $t('nav.callForMaps') }}</NuxtLinkLocale>
+<NuxtLinkLocale @click="close" to="/maps">{{ $t('nav.callForMaps') }}</NuxtLinkLocale>
                 <NuxtLinkLocale @click="close" to="/become-sponsor">{{ $t('nav.becomeSponsor') }}</NuxtLinkLocale>
                 <NuxtLinkLocale @click="close" to="/volunteer">{{ $t('nav.volunteer') }}</NuxtLinkLocale>
                 <NuxtLinkLocale @click="close" to="/contact">{{ $t('nav.contact') }}</NuxtLinkLocale>
@@ -105,13 +104,13 @@
                         v-for="loc in localesToPick"
                         :key="loc.code"
                     >
-                        <NuxtLinkLocale
+                        <NuxtLink
                             :to="switchLocalePath(loc.code)"
                             class="px-3 py-2 bg-white rounded hover:bg-gray-100 text-sm"
                             @click="close"
                         >
                             {{ loc.label }}
-                        </NuxtLinkLocale>
+                        </NuxtLink>
                     </li>
                 </ul>
             </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -291,9 +291,8 @@
     },
     "apply": {
       "title": "Get involved now",
-      "content": "No deadline — join the mailing list or the OSGeo Belgium Matrix channel to follow requests in real time and express your interest.",
-      "matrixLabel": "Join Matrix #osgeo-be",
-      "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
+      "content": "No deadline. Contact us by email or tick the volunteer option when registering your ticket on Pretix.",
+      "pretixLabel": "Register as volunteer on Pretix"
     }
   },
   "cards": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -291,9 +291,8 @@
     },
     "apply": {
       "title": "Comment s'impliquer maintenant",
-      "content": "Pas de date limite : inscrivez-vous à la mailing list ou rejoignez le salon Matrix OSGeo Belgium pour suivre les demandes en direct et manifester votre intérêt.",
-      "matrixLabel": "Rejoindre Matrix #osgeo-be",
-      "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
+      "content": "Pas de date limite. Contactez-nous par email ou cochez l'option bénévole lors de votre inscription sur Pretix.",
+      "pretixLabel": "S'inscrire comme bénévole sur Pretix"
     }
   },
   "cards": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -291,9 +291,8 @@
     },
     "apply": {
       "title": "Nu betrokken raken",
-      "content": "Geen deadline — schrijf u in op de mailinglijst of sluit u aan bij het OSGeo Belgium Matrix-kanaal om aanvragen live te volgen en uw interesse kenbaar te maken.",
-      "matrixLabel": "Matrix #osgeo-be vervoegen",
-      "matrixUrl": "https://matrix.to/#/#osgeo-be:matrix.org"
+      "content": "Geen deadline. Neem contact op via e-mail of vink de vrijwilligersoptie aan bij uw ticketregistratie op Pretix.",
+      "pretixLabel": "Inschrijven als vrijwilliger op Pretix"
     }
   },
   "cards": {

--- a/pages/volunteer.vue
+++ b/pages/volunteer.vue
@@ -8,9 +8,6 @@
                     <h1 class="text-xl font-bold mb-2">{{ $t('volunteer.title') }}</h1>
                     <p class="text-sm text-neutral-dark mb-3">{{ $t('volunteer.content') }}</p>
                     <div class="flex flex-wrap gap-3 text-xs">
-                        <span class="bg-main-color-4/10 text-main-color-4 font-semibold px-3 py-1 rounded-full">
-                            {{ $t('volunteer.timeline.opensLabel') }} {{ $t('volunteer.timeline.opensDate') }}
-                        </span>
                         <span class="bg-main-color-2/10 text-main-color-2 font-semibold px-3 py-1 rounded-full">
                             {{ $t('volunteer.timeline.eventDate') }}
                         </span>
@@ -66,15 +63,24 @@
             <div class="bg-off-white px-6 py-6 rounded-xl shadow">
                 <h2 class="text-lg font-bold mb-2">{{ $t('volunteer.apply.title') }}</h2>
                 <p class="text-sm text-neutral-dark mb-4">{{ $t('volunteer.apply.content') }}</p>
-                <a
-                    :href="$t('volunteer.apply.matrixUrl')"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center gap-2 border-2 border-main-color-4 text-main-color-4 font-semibold px-4 py-2 rounded-lg hover:bg-main-color-4 hover:text-white transition text-sm"
-                >
-                    <MdiIcon icon="mdiMatrix" size="1.1em" />
-                    {{ $t('volunteer.apply.matrixLabel') }}
-                </a>
+                <div class="flex flex-col sm:flex-row gap-3">
+                    <a
+                        href="mailto:info@foss4g.be"
+                        class="inline-flex items-center gap-2 bg-main-color-4 text-white font-semibold px-4 py-2 rounded-lg hover:opacity-90 transition text-sm"
+                    >
+                        <MdiIcon icon="mdiEmailOutline" size="1.1em" />
+                        info@foss4g.be
+                    </a>
+                    <a
+                        href="https://pretix.eu/osgeobe/foss4gbe/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-2 border-2 border-main-color-2 text-main-color-2 font-semibold px-4 py-2 rounded-lg hover:bg-main-color-2 hover:text-white transition text-sm"
+                    >
+                        <MdiIcon icon="mdiTicketOutline" size="1.1em" />
+                        {{ $t('volunteer.apply.pretixLabel') }}
+                    </a>
+                </div>
             </div>
 
         </section>
@@ -134,7 +140,6 @@ const roles = [
 ]
 
 const timeline = [
-    { dateKey: 'volunteer.timeline.opensDate',    labelKey: 'volunteer.timeline.opensLabel',    inPerson: false },
     { dateKey: 'volunteer.timeline.meetup1Date',  labelKey: 'volunteer.timeline.meetup1Label',  inPerson: true  },
     { dateKey: 'volunteer.timeline.meetup2Date',  labelKey: 'volunteer.timeline.meetup2Label',  inPerson: true  },
     { dateKey: 'volunteer.timeline.briefingDate', labelKey: 'volunteer.timeline.briefingLabel', inPerson: false },


### PR DESCRIPTION
- Navbar mobile: NuxtLinkLocale -> NuxtLink pour le sélecteur de langue (fix boucle locale)
- Navbar mobile: supprimer le lien Appel a Presentations (deadline dépassée)
- Volunteer hero: supprimer badge 'Ouverture inscriptions 7 juillet'
- Volunteer apply: remplacer section Matrix par bouton email info@foss4g.be + bouton Pretix
- Volunteer timeline: supprimer entree opensDate
- Locales EN/FR/NL: volunteer.apply sans matrixLabel/matrixUrl, pretixLabel ajouté, pas de @ dans les valeurs