### PR TITLE
become-sponsor: Community tier — formation + bouton mailto

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -377,8 +377,9 @@
       "community": {
         "title": "Community",
         "price": "€100",
-        "description": "Ideal for surveyors, independent consultants and companies wishing to support the event via their training budget.",
-        "cta": "Register as a Community Sponsor"
+        "description": "FOSS4G Belgium includes both presentations and practical workshops. If you or your company would like to support the event and count it as a training expense, we can issue an official invoice.",
+        "cta": "Contact us",
+        "mailSubject": "Community support request — FOSS4G Belgium 2026"
       }
     },
     "coc": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -377,8 +377,9 @@
       "community": {
         "title": "Community",
         "price": "100 €",
-        "description": "Idéal pour géomètres, consultants indépendants et entreprises souhaitant soutenir l'événement via leur budget formation.",
-        "cta": "S'inscrire comme Community sponsor"
+        "description": "FOSS4G Belgium propose des présentations et des ateliers pratiques. Si vous souhaitez soutenir l'événement et le valoriser comme formation dans votre organisation, nous pouvons émettre une facture officielle.",
+        "cta": "Nous contacter",
+        "mailSubject": "Demande de soutien Community — FOSS4G Belgium 2026"
       }
     },
     "coc": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -377,8 +377,9 @@
       "community": {
         "title": "Community",
         "price": "€100",
-        "description": "Ideaal voor landmeters, zelfstandige consultants en bedrijven die het evenement via hun opleidingsbudget willen ondersteunen.",
-        "cta": "Inschrijven als Community Sponsor"
+        "description": "FOSS4G Belgium omvat zowel presentaties als praktische workshops. Als u het evenement wilt steunen en dit als opleidingskosten wilt laten gelden, kunnen wij een officiële factuur opmaken.",
+        "cta": "Neem contact op",
+        "mailSubject": "Community-steunverzoek — FOSS4G Belgium 2026"
       }
     },
     "coc": {

--- a/pages/become-sponsor.vue
+++ b/pages/become-sponsor.vue
@@ -234,15 +234,14 @@ const bronzeSponsors: Sponsor[] = sponsorsData.bronze
                     <p class="text-xs text-neutral-dark italic mb-4">{{ $t('sponsors.tiers.community.description') }}</p>
                     <ul class="list-disc list-inside text-sm space-y-1 mb-4">
                         <li>{{ $t('sponsors.features.officialInvoice') }}</li>
-                        <li>{{ $t('sponsors.features.logoOnSponsorsPage') }}</li>
                     </ul>
                 </div>
-                <NuxtLinkLocale
-                    to="/contact?sponsor=community"
+                <a
+                    :href="`mailto:board@osgeo.be?subject=${encodeURIComponent($t('sponsors.tiers.community.mailSubject'))}`"
                     class="shrink-0 self-center border-2 border-primary text-primary hover:bg-primary hover:text-off-white font-semibold px-6 py-2 rounded-lg transition text-sm"
                 >
                     {{ $t('sponsors.tiers.community.cta') }}
-                </NuxtLinkLocale>
+                </a>
             </section>
         </main>
     </div>


### PR DESCRIPTION
- Remove logo benefit from Community tier (no logo on sponsors page)
- New description: FOSS4G has presentations + workshops, invoice can be issued as training expense
- CTA button replaced by mailto:board@osgeo.be with pre-filled subject (per locale: EN/FR/NL)