### PR TITLE
schedule: fix workshop time range display (90 min)

### DIFF
--- a/pages/schedule.vue
+++ b/pages/schedule.vue
@@ -625,7 +625,7 @@ function isTalkExpanded(time: string, track: string): boolean {
                             </span>
                           </div>
                           <time class="text-xs text-gray-600 font-medium">
-                            {{ formatTimeRange(slot.time, 30) }}
+                            {{ formatTimeRange(slot.time, talk.duration ?? 30) }}
                           </time>
                           <!-- Expand/Collapse Icon -->
                           <MdiIcon


### PR DESCRIPTION
Workshops are 90 minutes but the time range displayed on the cards was hardcoded to 30 minutes. This fix uses 	alk.duration when available, so workshops now correctly show 13:00 - 14:30 and 15:00 - 16:30.